### PR TITLE
ci: add conventional commits PR lint

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,15 @@
+name: Lint PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GitHub Action (`amannn/action-semantic-pull-request`) to validate PR titles against the conventional commits spec
- Runs on PR open, reopen, and edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)