### PR TITLE
chore: extract usage text into const string

### DIFF
--- a/cmd/twin/main.go
+++ b/cmd/twin/main.go
@@ -35,9 +35,11 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Fprintln(os.Stderr, "usage: twin <command>")
-	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "commands:")
-	fmt.Fprintln(os.Stderr, "  tspmo    spin up tmux sessions from recipes")
-	fmt.Fprintln(os.Stderr, "  sybau    fzf-based session switcher")
+	const usage = `usage: twin <command>
+
+commands:
+  tspmo    spin up tmux sessions from recipes
+  sybau    fzf-based session switcher
+`
+	fmt.Fprint(os.Stderr, usage)
 }


### PR DESCRIPTION
## Summary
- Replace repeated `fmt.Fprintln` calls in `printUsage()` with a single `const` string and `fmt.Fprint`

## Test plan
- [ ] Run `twin` with no args and verify help output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)