### PR TITLE
feat(fr): add subcommand to open a single recipe

### DIFF
--- a/cmd/twin/main.go
+++ b/cmd/twin/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Josef-Hlink/twin/internal/fr"
 	"github.com/Josef-Hlink/twin/internal/sybau"
 	"github.com/Josef-Hlink/twin/internal/tspmo"
 )
@@ -19,6 +20,8 @@ func main() {
 	switch os.Args[1] {
 	case "tspmo":
 		err = tspmo.Run()
+	case "fr":
+		err = fr.Run(os.Args[2:])
 	case "sybau":
 		err = sybau.Run()
 	case "sybau-picker":
@@ -39,6 +42,7 @@ func printUsage() {
 
 commands:
   tspmo    spin up tmux sessions from recipes
+  fr       open a single recipe (fzf picker / name / --list)
   sybau    fzf-based session switcher
 `
 	fmt.Fprint(os.Stderr, usage)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,24 @@ func LoadRecipe(recipeDir, name string) (Recipe, error) {
 	return r, nil
 }
 
+// ListRecipes returns the names of all recipe files (without .toml extension)
+// found in the given directory.
+func ListRecipes(recipeDir string) ([]string, error) {
+	entries, err := os.ReadDir(recipeDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading recipe dir %s: %w", recipeDir, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(e.Name(), ".toml"))
+	}
+	return names, nil
+}
+
 func configDir() string {
 	if dir := os.Getenv("TWIN_CONFIG_DIR"); dir != "" {
 		return expandPath(dir)

--- a/internal/fr/fr.go
+++ b/internal/fr/fr.go
@@ -1,0 +1,124 @@
+package fr
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/Josef-Hlink/twin/internal/config"
+	"github.com/Josef-Hlink/twin/internal/tmux"
+	"github.com/Josef-Hlink/twin/internal/tspmo"
+)
+
+// Run opens a single tmux session from a recipe.
+// With no args it launches fzf to pick one; with a name arg it opens directly;
+// with --list it prints all available recipe names.
+func Run(args []string) error {
+	if len(args) > 0 && args[0] == "--list" {
+		return list()
+	}
+	if len(args) > 0 {
+		return open(args[0])
+	}
+	return pick()
+}
+
+// list prints all available recipe names.
+func list() error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	names, err := config.ListRecipes(cfg.RecipeDir)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range names {
+		fmt.Println(name)
+	}
+	return nil
+}
+
+// open creates a tmux session from the named recipe.
+func open(name string) error {
+	if tmux.HasSession(name) {
+		fmt.Printf("skipped (already exists): %s\n", name)
+		return nil
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	recipe, err := config.LoadRecipe(cfg.RecipeDir, name)
+	if err != nil {
+		return err
+	}
+
+	if err := tspmo.CreateSession(name, recipe); err != nil {
+		return fmt.Errorf("creating session %s: %w", name, err)
+	}
+
+	fmt.Printf("created: %s\n", name)
+	return nil
+}
+
+// pick shows an fzf menu of recipes that don't have open sessions, and opens the selection.
+func pick() error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	names, err := config.ListRecipes(cfg.RecipeDir)
+	if err != nil {
+		return err
+	}
+
+	// Filter out recipes that already have a running session.
+	var available []string
+	for _, name := range names {
+		if !tmux.HasSession(name) {
+			available = append(available, name)
+		}
+	}
+
+	if len(available) == 0 {
+		fmt.Println("no unopened recipes available")
+		return nil
+	}
+
+	selected, err := fzfSelect(available)
+	if err != nil {
+		return fmt.Errorf("fzf: %w", err)
+	}
+	if selected == "" {
+		return nil // user cancelled
+	}
+
+	return open(selected)
+}
+
+// fzfSelect pipes the given lines to fzf and returns the selected line.
+func fzfSelect(items []string) (string, error) {
+	cmd := exec.Command("fzf")
+	cmd.Stdin = strings.NewReader(strings.Join(items, "\n"))
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// fzf exits 130 on Escape, 1 on no match — not errors.
+			if exitErr.ExitCode() == 130 || exitErr.ExitCode() == 1 {
+				return "", nil
+			}
+		}
+		return "", err
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/tspmo/tspmo.go
+++ b/internal/tspmo/tspmo.go
@@ -30,7 +30,7 @@ func Run() error {
 			continue
 		}
 
-		if err := createSession(name, recipe); err != nil {
+		if err := CreateSession(name, recipe); err != nil {
 			fmt.Fprintf(os.Stderr, "error creating %s: %v\n", name, err)
 			continue
 		}
@@ -52,7 +52,8 @@ func Run() error {
 	return nil
 }
 
-func createSession(name string, recipe config.Recipe) error {
+// CreateSession builds a tmux session from a recipe: creates windows and sends commands.
+func CreateSession(name string, recipe config.Recipe) error {
 	// The first window is created with the session itself (window index 1,
 	// since tmux base-index is commonly 1, but we use the default here).
 	baseDir := recipe.StartDirectory


### PR DESCRIPTION
Closes #10

## Summary

- Adds `twin fr` subcommand with three modes: fzf picker (no args), direct open (`twin fr <name>`), and `--list` flag
- Fzf picker filters out recipes that already have running sessions
- Exports `tspmo.CreateSession` so fr can reuse session creation logic
- Adds `config.ListRecipes` helper to enumerate recipe files

## Test plan

- [ ] `twin fr --list` prints all recipe names from recipe dir
- [ ] `twin fr` shows fzf with only unopened recipes
- [ ] `twin fr <name>` creates the session directly
- [ ] `twin fr <name>` on an existing session prints skip message
- [ ] `twin tspmo` still works (no regression from export rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)