### PR TITLE
feat(tspmo): add delay between session spawns to preserve ordering

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,8 +11,18 @@ import (
 
 // Config represents the top-level twin.toml file.
 type Config struct {
-	RecipeDir string   `toml:"recipe-dir"`
-	Active    []string `toml:"active"`
+	RecipeDir        string   `toml:"recipe-dir"`
+	Active           []string `toml:"active"`
+	OrderedSessions  *bool    `toml:"ordered-sessions"`
+}
+
+// IsOrderedSessions returns whether sessions should be created with delays
+// to preserve ordering. Defaults to true when not explicitly set.
+func (c Config) IsOrderedSessions() bool {
+	if c.OrderedSessions == nil {
+		return true
+	}
+	return *c.OrderedSessions
 }
 
 // Window represents a single window in a recipe.

--- a/internal/tspmo/tspmo.go
+++ b/internal/tspmo/tspmo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Josef-Hlink/twin/internal/config"
 	"github.com/Josef-Hlink/twin/internal/tmux"
@@ -17,6 +18,7 @@ func Run() error {
 	}
 
 	var created, skipped []string
+	ordered := cfg.IsOrderedSessions()
 
 	for _, name := range cfg.Active {
 		if tmux.HasSession(name) {
@@ -28,6 +30,12 @@ func Run() error {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "skipping %s: %v\n", name, err)
 			continue
+		}
+
+		// Sleep before creating the next session so tmux assigns distinct
+		// creation timestamps, preserving the order from the active list.
+		if ordered && len(created) > 0 {
+			time.Sleep(1 * time.Second)
 		}
 
 		if err := CreateSession(name, recipe); err != nil {


### PR DESCRIPTION
Closes #1

## Summary
- Add `ordered-sessions` config option (`*bool`, defaults to `true` when omitted)
- Sleep 1s between session creations so tmux assigns distinct `session_created` timestamps, preserving the order from the `active` list
- Can be disabled with `ordered-sessions = false` in `twin.toml`

## Test plan
- [ ] Run `twin tspmo` with multiple active recipes, verify `tmux list-sessions -F '#{session_created} #{session_name}'` shows ascending timestamps matching the `active` order
- [ ] Verify `ordered-sessions = false` in `twin.toml` skips the delay
- [ ] Verify default behavior (no `ordered-sessions` key) preserves ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)