### PR TITLE
feat(icl): interactive tabbed quickview popup

### DIFF
--- a/cmd/twin/main.go
+++ b/cmd/twin/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Josef-Hlink/twin/internal/fr"
+	"github.com/Josef-Hlink/twin/internal/icl"
 	"github.com/Josef-Hlink/twin/internal/sybau"
 	"github.com/Josef-Hlink/twin/internal/tspmo"
 )
@@ -26,6 +27,10 @@ func main() {
 		err = sybau.Run(os.Args[2:])
 	case "sybau-picker":
 		err = sybau.RunPicker(os.Args[2:])
+	case "icl":
+		err = icl.Run()
+	case "icl-view":
+		err = icl.RunView()
 	default:
 		printUsage()
 		os.Exit(1)
@@ -44,6 +49,7 @@ commands:
   tspmo    spin up tmux sessions from recipes
   fr       open a single recipe (fzf picker / name / --list)
   sybau    fzf-based session switcher
+  icl      quick-glance at running Claude agent panes
 `
 	fmt.Fprint(os.Stderr, usage)
 }

--- a/internal/icl/icl.go
+++ b/internal/icl/icl.go
@@ -47,7 +47,7 @@ func Run() error {
 		height = 10
 	}
 
-	return tmux.DisplayPopupCenter("icl", width, height, "fg=colour214,bold", self+" icl-view")
+	return tmux.DisplayPopup(tmux.PopupCenter, "icl", width, height, "fg=colour214,bold", self+" icl-view")
 }
 
 // RunView renders the interactive tabbed Claude pane viewer. Runs inside the popup.

--- a/internal/icl/icl.go
+++ b/internal/icl/icl.go
@@ -1,0 +1,190 @@
+package icl
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/Josef-Hlink/twin/internal/tmux"
+)
+
+const (
+	captureLines = 10
+	maxCols      = 50
+)
+
+// Run spawns a right-side tmux popup showing Claude agent pane contents.
+func Run() error {
+	panes, err := findClaudePanes()
+	if err != nil {
+		return err
+	}
+	if len(panes) == 0 {
+		fmt.Println("no claude panes found")
+		return nil
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving executable path: %w", err)
+	}
+
+	_, clientH, _ := tmux.ClientSize()
+	width := maxCols + 4
+	contentH := len(panes)*(captureLines+3) + 3
+	height := min(contentH, clientH-2)
+	height = max(height, 10)
+
+	return tmux.DisplayPopupRight("icl", width, height, "fg=colour214,bold", self+" icl-view")
+}
+
+// RunView renders Claude pane summaries and exits. Runs inside the popup.
+// The popup closes automatically when this returns (tmux -E flag).
+func RunView() error {
+	panes, err := findClaudePanes()
+	if err != nil {
+		return err
+	}
+	if len(panes) == 0 {
+		fmt.Println("no claude panes found")
+		return nil
+	}
+
+	orange := "\033[38;5;214m"
+	reset := "\033[0m"
+	for i, p := range panes {
+		label := fmt.Sprintf("%s:%d", p.SessionName, p.WindowIndex)
+		// ━━ label ━━━━━━━━━━━━━━━━━━━━
+		pad := maxCols - len("━━"+" "+label+" ") // leading ━━, spaces around label
+		if pad < 2 {
+			pad = 2
+		}
+		fmt.Printf("%s━━ %s %s%s\n", orange, label, strings.Repeat("━", pad), reset)
+
+		content, err := tmux.CapturePane(p.Target)
+		if err != nil {
+			fmt.Printf("  (error: %v)\n", err)
+			continue
+		}
+
+		for _, line := range lastLines(content, captureLines) {
+			fmt.Println(trunc(line, maxCols))
+		}
+		if i < len(panes)-1 {
+			fmt.Println()
+		}
+	}
+
+	// Wait for any keypress to dismiss.
+	fmt.Print("\npress any key to close")
+	b := make([]byte, 1)
+	os.Stdin.Read(b)
+	return nil
+}
+
+// --- Claude pane detection ---
+
+type proc struct {
+	ppid int
+	args string
+}
+
+func findClaudePanes() ([]tmux.Pane, error) {
+	all, err := tmux.ListAllPanes()
+	if err != nil {
+		return nil, fmt.Errorf("listing panes: %w", err)
+	}
+
+	procs, err := allProcesses()
+	if err != nil {
+		// Fallback: just check the pane's foreground command.
+		var matched []tmux.Pane
+		for _, p := range all {
+			if strings.Contains(strings.ToLower(p.Command), "claude") {
+				matched = append(matched, p)
+			}
+		}
+		return matched, nil
+	}
+
+	// Build children map for tree walking.
+	children := make(map[int][]int)
+	for pid, p := range procs {
+		children[p.ppid] = append(children[p.ppid], pid)
+	}
+
+	var matched []tmux.Pane
+	for _, p := range all {
+		if strings.Contains(strings.ToLower(p.Command), "claude") {
+			matched = append(matched, p)
+			continue
+		}
+		if hasClaude(p.PanePID, procs, children) {
+			matched = append(matched, p)
+		}
+	}
+	return matched, nil
+}
+
+func allProcesses() (map[int]proc, error) {
+	out, err := exec.Command("ps", "-Ao", "pid=", "-o", "ppid=", "-o", "args=").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	procs := make(map[int]proc)
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, _ := strconv.Atoi(fields[0])
+		ppid, _ := strconv.Atoi(fields[1])
+		if pid == 0 {
+			continue
+		}
+		procs[pid] = proc{ppid: ppid, args: strings.Join(fields[2:], " ")}
+	}
+	return procs, nil
+}
+
+// hasClaude walks the process tree from rootPID looking for a claude process.
+func hasClaude(rootPID int, procs map[int]proc, children map[int][]int) bool {
+	queue := children[rootPID]
+	for len(queue) > 0 {
+		pid := queue[0]
+		queue = queue[1:]
+		if p, ok := procs[pid]; ok {
+			if strings.Contains(strings.ToLower(p.args), "claude") {
+				return true
+			}
+			queue = append(queue, children[pid]...)
+		}
+	}
+	return false
+}
+
+// --- Text formatting ---
+
+// lastLines trims trailing blank lines and returns the last n lines.
+func lastLines(content string, n int) []string {
+	lines := strings.Split(content, "\n")
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return lines
+}
+
+// trunc truncates a string to n visible runes.
+func trunc(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) > n {
+		return string(runes[:n])
+	}
+	return s
+}

--- a/internal/icl/icl.go
+++ b/internal/icl/icl.go
@@ -2,20 +2,26 @@ package icl
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/Josef-Hlink/twin/internal/tmux"
 )
 
-const (
-	captureLines = 10
-	maxCols      = 50
-)
+// claudePane wraps a tmux pane with cached content and detected state.
+type claudePane struct {
+	pane    tmux.Pane
+	label   string // "session:window"
+	content string // captured pane output
+	state   byte   // '*' busy, '&' menu, '-' idle
+}
 
-// Run spawns a right-side tmux popup showing Claude agent pane contents.
+// Run spawns a centered tmux popup showing the interactive Claude quickview.
 func Run() error {
 	panes, err := findClaudePanes()
 	if err != nil {
@@ -31,17 +37,20 @@ func Run() error {
 		return fmt.Errorf("resolving executable path: %w", err)
 	}
 
-	_, clientH, _ := tmux.ClientSize()
-	width := maxCols + 4
-	contentH := len(panes)*(captureLines+3) + 3
-	height := min(contentH, clientH-2)
-	height = max(height, 10)
+	clientW, clientH, _ := tmux.ClientSize()
+	width := clientW * 80 / 100
+	if width < 40 {
+		width = 40
+	}
+	height := clientH * 70 / 100
+	if height < 10 {
+		height = 10
+	}
 
-	return tmux.DisplayPopupRight("icl", width, height, "fg=colour214,bold", self+" icl-view")
+	return tmux.DisplayPopupCenter("icl", width, height, "fg=colour214,bold", self+" icl-view")
 }
 
-// RunView renders Claude pane summaries and exits. Runs inside the popup.
-// The popup closes automatically when this returns (tmux -E flag).
+// RunView renders the interactive tabbed Claude pane viewer. Runs inside the popup.
 func RunView() error {
 	panes, err := findClaudePanes()
 	if err != nil {
@@ -52,36 +61,263 @@ func RunView() error {
 		return nil
 	}
 
-	orange := "\033[38;5;214m"
-	reset := "\033[0m"
+	// Build claudePane list with captured content and state.
+	cPanes := make([]claudePane, len(panes))
 	for i, p := range panes {
 		label := fmt.Sprintf("%s:%d", p.SessionName, p.WindowIndex)
-		// ━━ label ━━━━━━━━━━━━━━━━━━━━
-		pad := maxCols - len("━━"+" "+label+" ") // leading ━━, spaces around label
-		if pad < 2 {
-			pad = 2
-		}
-		fmt.Printf("%s━━ %s %s%s\n", orange, label, strings.Repeat("━", pad), reset)
-
-		content, err := tmux.CapturePane(p.Target)
-		if err != nil {
-			fmt.Printf("  (error: %v)\n", err)
-			continue
-		}
-
-		for _, line := range lastLines(content, captureLines) {
-			fmt.Println(trunc(line, maxCols))
-		}
-		if i < len(panes)-1 {
-			fmt.Println()
+		content, _ := tmux.CapturePane(p.Target)
+		cPanes[i] = claudePane{
+			pane:    p,
+			label:   label,
+			content: content,
+			state:   detectState(content),
 		}
 	}
 
-	// Wait for any keypress to dismiss.
-	fmt.Print("\npress any key to close")
-	b := make([]byte, 1)
-	os.Stdin.Read(b)
+	// Get popup terminal size via stty.
+	width, height := termSize()
+	if width == 0 || height == 0 {
+		width, height = 80, 24
+	}
+
+	// Enter raw mode.
+	restore, err := sttyRaw()
+	if err != nil {
+		return fmt.Errorf("entering raw mode: %w", err)
+	}
+	defer restore()
+
+	selected := 0
+	buf := make([]byte, 3)
+
+	for {
+		render(os.Stdout, cPanes, selected, width, height)
+
+		n, err := os.Stdin.Read(buf)
+		if err != nil {
+			break
+		}
+
+		switch {
+		// Escape key alone
+		case n == 1 && buf[0] == 27:
+			return nil
+		// q to quit
+		case n == 1 && buf[0] == 'q':
+			return nil
+		// Enter: switch to pane
+		case n == 1 && buf[0] == 13:
+			p := cPanes[selected].pane
+			target := fmt.Sprintf("%s:%d", p.SessionName, p.WindowIndex)
+			tmux.SwitchClient(p.SessionName)
+			tmux.SelectWindow(target)
+			return nil
+		// h/H or left arrow: previous tab
+		case n == 1 && (buf[0] == 'h' || buf[0] == 'H'):
+			selected = (selected - 1 + len(cPanes)) % len(cPanes)
+		case n == 3 && buf[0] == 27 && buf[1] == '[' && buf[2] == 'D':
+			selected = (selected - 1 + len(cPanes)) % len(cPanes)
+		// l/L or right arrow: next tab
+		case n == 1 && (buf[0] == 'l' || buf[0] == 'L'):
+			selected = (selected + 1) % len(cPanes)
+		case n == 3 && buf[0] == 27 && buf[1] == '[' && buf[2] == 'C':
+			selected = (selected + 1) % len(cPanes)
+		}
+	}
+
 	return nil
+}
+
+// --- Terminal helpers ---
+
+// sttyRaw puts the terminal in raw mode and returns a function to restore it.
+func sttyRaw() (restore func(), err error) {
+	// Save current settings. Must connect stdin so stty sees the terminal.
+	save := exec.Command("stty", "-g")
+	save.Stdin = os.Stdin
+	out, err := save.Output()
+	if err != nil {
+		return nil, err
+	}
+	saved := strings.TrimSpace(string(out))
+
+	// Enter raw mode.
+	raw := exec.Command("stty", "raw", "-echo")
+	raw.Stdin = os.Stdin
+	if err := raw.Run(); err != nil {
+		return nil, err
+	}
+
+	return func() {
+		cmd := exec.Command("stty", saved)
+		cmd.Stdin = os.Stdin
+		cmd.Run()
+	}, nil
+}
+
+// termSize returns terminal cols and rows via stty size.
+func termSize() (width, height int) {
+	cmd := exec.Command("stty", "size")
+	cmd.Stdin = os.Stdin
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, 0
+	}
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) < 2 {
+		return 0, 0
+	}
+	h, _ := strconv.Atoi(fields[0])
+	w, _ := strconv.Atoi(fields[1])
+	return w, h
+}
+
+// --- State detection ---
+
+var menuLineRe = regexp.MustCompile(`^\s*\d+\.\s`)
+
+// detectState scans the last ~20 lines of captured content to determine pane state.
+func detectState(content string) byte {
+	lines := lastLines(content, 20)
+
+	// Check last 10 lines for menu pattern (2+ matches = menu).
+	scanLines := lines
+	if len(scanLines) > 10 {
+		scanLines = scanLines[len(scanLines)-10:]
+	}
+	menuCount := 0
+	for _, line := range scanLines {
+		if isMenuLine(line) {
+			menuCount++
+		}
+	}
+	if menuCount >= 2 {
+		return '&'
+	}
+
+	// Check all 20 lines for busy pattern.
+	for i := len(lines) - 1; i >= 0; i-- {
+		if isBusyLine(lines[i]) {
+			return '*'
+		}
+	}
+
+	return '-'
+}
+
+// isMenuLine checks if a line matches the "N. " pattern (digit, dot, space).
+func isMenuLine(line string) bool {
+	return menuLineRe.MatchString(line)
+}
+
+// isBusyLine checks if a line contains a word ending in "ing…" or "ing..."
+// which matches Claude's spinner status text (Crunching…, Reading…, etc.).
+func isBusyLine(line string) bool {
+	for w := range strings.FieldsSeq(line) {
+		lower := strings.ToLower(w)
+		if strings.HasSuffix(lower, "ing…") || strings.HasSuffix(lower, "ing...") {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Rendering ---
+
+const (
+	ansiOrange  = "\033[38;5;214m"
+	ansiReverse = "\033[7m"
+	ansiReset   = "\033[0m"
+	ansiClear = "\033[2J\033[H" // clear screen + cursor home
+	ansiDim   = "\033[2m"
+)
+
+// render draws the full TUI: tab bar, separator, preview, status line.
+func render(w io.Writer, panes []claudePane, selected, width, height int) {
+	var b strings.Builder
+
+	// Clear screen and move cursor home.
+	b.WriteString(ansiClear)
+
+	// --- Tab bar (line 1) ---
+	b.WriteString(ansiOrange)
+	var tabBar strings.Builder
+	for i, p := range panes {
+		tab := fmt.Sprintf(" %s %c ", p.label, p.state)
+		if i == selected {
+			tabBar.WriteString(ansiReverse)
+			tabBar.WriteString(tab)
+			tabBar.WriteString(ansiReset)
+			tabBar.WriteString(ansiOrange)
+		} else {
+			tabBar.WriteString(tab)
+		}
+		if i < len(panes)-1 {
+			tabBar.WriteString("|")
+		}
+	}
+	// Pad or truncate tab bar to width.
+	tabStr := tabBar.String()
+	b.WriteString(tabStr)
+	b.WriteString(ansiReset)
+	b.WriteString("\r\n")
+
+	// --- Separator (line 2) ---
+	b.WriteString(ansiOrange)
+	b.WriteString(strings.Repeat("━", width))
+	b.WriteString(ansiReset)
+	b.WriteString("\r\n")
+
+	// --- Preview area (lines 3 to height-1) ---
+	previewHeight := max(height-3, 1) // tab bar + separator + status line
+
+	content := panes[selected].content
+	previewLines := lastLines(content, previewHeight)
+
+	for i := range previewHeight {
+		if i < len(previewLines) {
+			line := truncVisible(previewLines[i], width)
+			b.WriteString(line)
+			b.WriteString(ansiReset) // prevent color bleed across lines
+		}
+		b.WriteString("\r\n")
+	}
+
+	// --- Status line (last line) ---
+	b.WriteString(ansiDim)
+	status := " H/L: navigate  Enter: switch  q: close"
+	b.WriteString(truncVisible(status, width))
+	b.WriteString(ansiReset)
+
+	w.Write([]byte(b.String()))
+}
+
+// truncVisible truncates a string to n visible columns, skipping ANSI
+// escape sequences so they don't count toward the width.
+func truncVisible(s string, n int) string {
+	visible := 0
+	i := 0
+	for i < len(s) {
+		// Skip ANSI escape sequences (\033[...m).
+		if i+1 < len(s) && s[i] == '\033' && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && s[j] != 'm' {
+				j++
+			}
+			if j < len(s) {
+				j++ // skip the 'm'
+			}
+			i = j
+			continue
+		}
+		_, size := utf8.DecodeRuneInString(s[i:])
+		visible++
+		if visible > n {
+			return s[:i]
+		}
+		i += size
+	}
+	return s
 }
 
 // --- Claude pane detection ---
@@ -135,7 +371,7 @@ func allProcesses() (map[int]proc, error) {
 	}
 
 	procs := make(map[int]proc)
-	for _, line := range strings.Split(string(out), "\n") {
+	for line := range strings.SplitSeq(string(out), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 3 {
 			continue
@@ -178,13 +414,4 @@ func lastLines(content string, n int) []string {
 		lines = lines[len(lines)-n:]
 	}
 	return lines
-}
-
-// trunc truncates a string to n visible runes.
-func trunc(s string, n int) string {
-	runes := []rune(s)
-	if len(runes) > n {
-		return string(runes[:n])
-	}
-	return s
 }

--- a/internal/sybau/sybau.go
+++ b/internal/sybau/sybau.go
@@ -81,7 +81,7 @@ func Run(args []string) error {
 	if preview {
 		cmd += " --preview"
 	}
-	return tmux.DisplayPopup("sybau", width, height, "fg=magenta bold", cmd)
+	return tmux.DisplayPopup(tmux.PopupTopLeft, "sybau", width, height, "fg=magenta bold", cmd)
 }
 
 // RunPicker lists tmux sessions, lets the user pick one via fzf, and switches to it.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"sort"
@@ -114,4 +115,96 @@ func AttachSession(name string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// Pane represents a single tmux pane.
+type Pane struct {
+	SessionName string
+	WindowIndex int
+	WindowName  string
+	PaneIndex   int
+	PanePID     int
+	Command     string
+	Target      string // "session:window.pane"
+}
+
+// ListAllPanes returns every pane across all tmux sessions.
+func ListAllPanes() ([]Pane, error) {
+	out, err := exec.Command("tmux", "list-panes", "-a",
+		"-F", "#{session_name}\t#{window_index}\t#{window_name}\t#{pane_index}\t#{pane_pid}\t#{pane_current_command}").Output()
+	if err != nil {
+		return nil, err
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil, nil
+	}
+
+	var panes []Pane
+	for _, line := range strings.Split(raw, "\n") {
+		fields := strings.Split(line, "\t")
+		if len(fields) < 6 {
+			continue
+		}
+		wIdx, _ := strconv.Atoi(fields[1])
+		pIdx, _ := strconv.Atoi(fields[3])
+		pid, _ := strconv.Atoi(fields[4])
+		panes = append(panes, Pane{
+			SessionName: fields[0],
+			WindowIndex: wIdx,
+			WindowName:  fields[2],
+			PaneIndex:   pIdx,
+			PanePID:     pid,
+			Command:     fields[5],
+			Target:      fmt.Sprintf("%s:%d.%d", fields[0], wIdx, pIdx),
+		})
+	}
+	return panes, nil
+}
+
+// CapturePane captures the visible content of a tmux pane as plain text.
+func CapturePane(target string) (string, error) {
+	out, err := exec.Command("tmux", "capture-pane", "-t", target, "-p").Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// ClientSize returns the width and height of the current tmux client.
+func ClientSize() (width, height int, err error) {
+	out, err := exec.Command("tmux", "display-message", "-p", "#{client_width}\t#{client_height}").Output()
+	if err != nil {
+		return 0, 0, err
+	}
+	fields := strings.Split(strings.TrimSpace(string(out)), "\t")
+	if len(fields) < 2 {
+		return 0, 0, fmt.Errorf("unexpected output: %s", out)
+	}
+	w, _ := strconv.Atoi(fields[0])
+	h, _ := strconv.Atoi(fields[1])
+	return w, h, nil
+}
+
+// DisplayPopupRight opens a tmux popup anchored to the right side, vertically centered.
+func DisplayPopupRight(title string, width, height int, style, command string) error {
+	clientW, clientH, _ := ClientSize()
+	x := clientW - width
+	if x < 0 {
+		x = 0
+	}
+	y := (clientH - height) / 2
+	if y < 0 {
+		y = 0
+	}
+
+	return exec.Command("tmux", "display-popup",
+		"-T", title,
+		"-x", strconv.Itoa(x),
+		"-y", strconv.Itoa(y),
+		"-w", strconv.Itoa(width),
+		"-h", strconv.Itoa(height),
+		"-S", style,
+		"-E", command,
+	).Run()
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -89,12 +89,32 @@ func ListWindows(session string) ([]string, error) {
 	return strings.Split(raw, "\n"), nil
 }
 
-// DisplayPopup opens a tmux popup anchored to the top-left corner.
-func DisplayPopup(title string, width, height int, style, command string) error {
+// PopupAnchor controls where a popup is positioned on screen.
+type PopupAnchor int
+
+const (
+	PopupTopLeft PopupAnchor = iota // flush top-left, row 0 stays visible
+	PopupCenter                     // centered on screen
+)
+
+// DisplayPopup opens a tmux popup at the given anchor position.
+func DisplayPopup(anchor PopupAnchor, title string, width, height int, style, command string) error {
+	clientW, clientH, _ := ClientSize()
+
+	var x, y int
+	switch anchor {
+	case PopupTopLeft:
+		x = 0
+		y = height + 1
+	case PopupCenter:
+		x = (clientW - width) / 2
+		y = (clientH + height) / 2
+	}
+
 	return exec.Command("tmux", "display-popup",
 		"-T", title,
-		"-x", "0",
-		"-y", strconv.Itoa(height+1),
+		"-x", strconv.Itoa(x),
+		"-y", strconv.Itoa(y),
 		"-w", strconv.Itoa(width),
 		"-h", strconv.Itoa(height),
 		"-S", style,
@@ -184,38 +204,4 @@ func ClientSize() (width, height int, err error) {
 	w, _ := strconv.Atoi(fields[0])
 	h, _ := strconv.Atoi(fields[1])
 	return w, h, nil
-}
-
-// DisplayPopupCenter opens a tmux popup centered on the screen.
-func DisplayPopupCenter(title string, width, height int, style, command string) error {
-	clientW, clientH, _ := ClientSize()
-	x := max((clientW-width)/2, 0)
-	y := max((clientH-height)/2, 0)
-
-	return exec.Command("tmux", "display-popup",
-		"-T", title,
-		"-x", strconv.Itoa(x),
-		"-y", strconv.Itoa(y),
-		"-w", strconv.Itoa(width),
-		"-h", strconv.Itoa(height),
-		"-S", style,
-		"-E", command,
-	).Run()
-}
-
-// DisplayPopupRight opens a tmux popup anchored to the right side, vertically centered.
-func DisplayPopupRight(title string, width, height int, style, command string) error {
-	clientW, clientH, _ := ClientSize()
-	x := max(clientW-width, 0)
-	y := max((clientH-height)/2, 0)
-
-	return exec.Command("tmux", "display-popup",
-		"-T", title,
-		"-x", strconv.Itoa(x),
-		"-y", strconv.Itoa(y),
-		"-w", strconv.Itoa(width),
-		"-h", strconv.Itoa(height),
-		"-S", style,
-		"-E", command,
-	).Run()
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -141,7 +141,7 @@ func ListAllPanes() ([]Pane, error) {
 	}
 
 	var panes []Pane
-	for _, line := range strings.Split(raw, "\n") {
+	for line := range strings.SplitSeq(raw, "\n") {
 		fields := strings.Split(line, "\t")
 		if len(fields) < 6 {
 			continue
@@ -162,9 +162,9 @@ func ListAllPanes() ([]Pane, error) {
 	return panes, nil
 }
 
-// CapturePane captures the visible content of a tmux pane as plain text.
+// CapturePane captures the visible content of a tmux pane, preserving ANSI escape sequences.
 func CapturePane(target string) (string, error) {
-	out, err := exec.Command("tmux", "capture-pane", "-t", target, "-p").Output()
+	out, err := exec.Command("tmux", "capture-pane", "-t", target, "-p", "-e").Output()
 	if err != nil {
 		return "", err
 	}
@@ -186,17 +186,28 @@ func ClientSize() (width, height int, err error) {
 	return w, h, nil
 }
 
+// DisplayPopupCenter opens a tmux popup centered on the screen.
+func DisplayPopupCenter(title string, width, height int, style, command string) error {
+	clientW, clientH, _ := ClientSize()
+	x := max((clientW-width)/2, 0)
+	y := max((clientH-height)/2, 0)
+
+	return exec.Command("tmux", "display-popup",
+		"-T", title,
+		"-x", strconv.Itoa(x),
+		"-y", strconv.Itoa(y),
+		"-w", strconv.Itoa(width),
+		"-h", strconv.Itoa(height),
+		"-S", style,
+		"-E", command,
+	).Run()
+}
+
 // DisplayPopupRight opens a tmux popup anchored to the right side, vertically centered.
 func DisplayPopupRight(title string, width, height int, style, command string) error {
 	clientW, clientH, _ := ClientSize()
-	x := clientW - width
-	if x < 0 {
-		x = 0
-	}
-	y := (clientH - height) / 2
-	if y < 0 {
-		y = 0
-	}
+	x := max(clientW-width, 0)
+	y := max((clientH-height)/2, 0)
 
 	return exec.Command("tmux", "display-popup",
 		"-T", title,


### PR DESCRIPTION
## Summary
- Replaces the static `twin icl` popup with an interactive tabbed viewer: horizontal tab bar with per-pane state indicators (`*` busy, `&` menu, `-` idle), full color preview of captured content, and keyboard navigation (H/L/arrows, Enter to switch, q/Esc to close)
- Popup is centered at 80% width / 70% height of the tmux client
- Unifies three popup positioning functions (`DisplayPopup`, `DisplayPopupCenter`, `DisplayPopupRight`) into a single `DisplayPopup(anchor, ...)` with `PopupTopLeft` and `PopupCenter` variants

## Test plan
- [ ] Open 2-3 tmux sessions with Claude running in various states
- [ ] Run `twin icl` — popup should appear centered with tab bar
- [ ] Press H/L or arrow keys — tabs cycle, preview updates with color
- [ ] Verify state indicators match Claude's actual state
- [ ] Press Enter — popup closes and switches to that session:window
- [ ] Press q or Esc — popup closes without switching
- [ ] Test with single Claude pane (no crash, tab bar still renders)
- [ ] Test with no Claude panes (graceful exit)
- [ ] Test `twin sybau` still works (top-left popup unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)