### PR TITLE
feat(shkspr): open twin.toml in $EDITOR

### DIFF
--- a/cmd/twin/main.go
+++ b/cmd/twin/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Josef-Hlink/twin/internal/fr"
+	"github.com/Josef-Hlink/twin/internal/shkspr"
 	"github.com/Josef-Hlink/twin/internal/sybau"
 	"github.com/Josef-Hlink/twin/internal/tspmo"
 	"github.com/Josef-Hlink/twin/internal/tysm"
@@ -31,6 +32,8 @@ func main() {
 		err = sybau.RunPicker(os.Args[2:])
 	case "tysm":
 		err = tysm.Run(os.Args[2:])
+	case "shkspr":
+		err = shkspr.Run(os.Args[2:])
 	default:
 		printUsage()
 		os.Exit(1)
@@ -49,6 +52,7 @@ commands:
   tspmo    spin up tmux sessions from recipes
   fr       open a single recipe (fzf picker / name / --list)
   sybau    fzf-based session switcher
+  shkspr   open twin.toml in $EDITOR
 `
 	fmt.Fprint(os.Stderr, usage)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,6 +95,11 @@ func ListRecipes(recipeDir string) ([]string, error) {
 	return names, nil
 }
 
+// ConfigPath returns the full path to the twin.toml config file.
+func ConfigPath() string {
+	return filepath.Join(configDir(), "twin.toml")
+}
+
 func configDir() string {
 	if dir := os.Getenv("TWIN_CONFIG_DIR"); dir != "" {
 		return expandPath(dir)

--- a/internal/shkspr/shkspr.go
+++ b/internal/shkspr/shkspr.go
@@ -1,6 +1,7 @@
 package shkspr
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -8,14 +9,31 @@ import (
 	"github.com/Josef-Hlink/twin/internal/config"
 )
 
-// Run opens the twin.toml config file in the user's editor.
+// Run opens the twin.toml config file or the recipes directory in the
+// user's editor.
 func Run(args []string) error {
+	fs := flag.NewFlagSet("shkspr", flag.ContinueOnError)
+	recipes := fs.Bool("recipes", false, "open the recipes directory")
+	fs.BoolVar(recipes, "r", false, "open the recipes directory (shorthand)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
 	editor, err := resolveEditor()
 	if err != nil {
 		return err
 	}
 
-	path := config.ConfigPath()
+	var path string
+	if *recipes {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		path = cfg.RecipeDir
+	} else {
+		path = config.ConfigPath()
+	}
 
 	cmd := exec.Command(editor, path)
 	cmd.Stdin = os.Stdin

--- a/internal/shkspr/shkspr.go
+++ b/internal/shkspr/shkspr.go
@@ -1,0 +1,39 @@
+package shkspr
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/Josef-Hlink/twin/internal/config"
+)
+
+// Run opens the twin.toml config file in the user's editor.
+func Run(args []string) error {
+	editor, err := resolveEditor()
+	if err != nil {
+		return err
+	}
+
+	path := config.ConfigPath()
+
+	cmd := exec.Command(editor, path)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// resolveEditor returns the first available editor from:
+// $EDITOR, vim, nano.
+func resolveEditor() (string, error) {
+	if editor := os.Getenv("EDITOR"); editor != "" {
+		return editor, nil
+	}
+	for _, name := range []string{"vim", "nano"} {
+		if _, err := exec.LookPath(name); err == nil {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("no valid editor found on system (set $EDITOR)")
+}


### PR DESCRIPTION
## Summary
- Adds `twin shkspr` subcommand that opens `twin.toml` in the user's editor
- Editor resolution: `$EDITOR` → `vim` → `nano` → error
- `--recipes`/`-r` flag opens the recipes directory instead
- Adds `ConfigPath()` helper to config package

Closes #28

## Test plan
- [x] `twin shkspr` opens twin.toml in `$EDITOR`
- [x] `twin shkspr` falls back to vim/nano when `$EDITOR` is unset
- [x] `twin shkspr -r` opens the recipes directory
- [x] `TWIN_CONFIG_DIR` is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)