### PR TITLE
feat(tysm): print farewell in parent shell after teardown

### DIFF
--- a/cmd/twin/main.go
+++ b/cmd/twin/main.go
@@ -98,7 +98,7 @@ commands:
   pbqt     kill a tmux session (fzf picker / name)
   icl      quick-glance at running Claude agent panes
   shkspr   open twin.toml in $EDITOR
-  tysm     teardown: kill the tmux server
+  tysm     kill tmux server with a farewell
 
 run 'twin <command> --help' for command-specific help.
 `

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -211,6 +211,31 @@ func KillSession(name string) error {
 	return exec.Command("tmux", "kill-session", "-t", name).Run()
 }
 
+// ClientTTY returns the TTY of the current tmux client (e.g. "/dev/ttys001").
+func ClientTTY() (string, error) {
+	out, err := exec.Command("tmux", "display-message", "-p", "#{client_tty}").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ClientPID returns the PID of the process that launched the tmux client
+// (typically the parent shell).
+func ClientPID() (string, error) {
+	out, err := exec.Command("tmux", "display-message", "-p", "#{client_pid}").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// DetachClient detaches the current tmux client, returning control to the
+// parent terminal.
+func DetachClient() error {
+	return exec.Command("tmux", "detach-client").Run()
+}
+
 // KillServer kills the tmux server, terminating all sessions.
 func KillServer() error {
 	return exec.Command("tmux", "kill-server").Run()

--- a/internal/tysm/tysm.go
+++ b/internal/tysm/tysm.go
@@ -2,6 +2,9 @@ package tysm
 
 import (
 	"flag"
+	"fmt"
+	"os/exec"
+	"syscall"
 
 	"github.com/Josef-Hlink/twin/internal/config"
 	"github.com/Josef-Hlink/twin/internal/tmux"
@@ -13,7 +16,11 @@ teardown: kill the tmux server and print a farewell message.
   --message, -m custom farewell message
 `
 
-// Run loads the config, and just kills the tmux server.
+const defaultMsg = "thank you so much twin 🥀"
+
+// Run kills the tmux server and prints a farewell message.
+// When running inside tmux, it spawns a detached process to print the message
+// to the parent terminal's TTY after the server is gone.
 func Run(args []string) error {
 	fs := flag.NewFlagSet("tysm", flag.ContinueOnError)
 	message := fs.String("message", "", "custom farewell message")
@@ -27,18 +34,54 @@ func Run(args []string) error {
 		return err
 	}
 
-	if err := tmux.KillServer(); err != nil {
-		return err
+	msg := resolveMessage(*message, cfg.TysmMsg)
+
+	if !tmux.InTmux() {
+		if err := tmux.KillServer(); err != nil {
+			return err
+		}
+		fmt.Println(msg)
+		return nil
 	}
 
-	// Print flag message if set, otherwise config message if set, otherwise default message
-	if *message != "" {
-		println(*message)
-	} else if cfg.TysmMsg != "" {
-		println(cfg.TysmMsg)
-	} else {
-		println("thank you so much twin 🥀")
+	// Inside tmux: grab the parent terminal's TTY and PID before detaching,
+	// then hand off to a background process that prints the farewell cleanly.
+	tty, err := tmux.ClientTTY()
+	if err != nil {
+		return fmt.Errorf("getting client tty: %w", err)
+	}
+	pid, err := tmux.ClientPID()
+	if err != nil {
+		return fmt.Errorf("getting client pid: %w", err)
+	}
+
+	// Detach first so the parent shell's "tmux attach" exits 0.
+	if err := tmux.DetachClient(); err != nil {
+		return fmt.Errorf("detaching client: %w", err)
+	}
+
+	// Spawn a detached process: brief sleep for the prompt to redraw,
+	// print the farewell below it, kill the server, then SIGWINCH the
+	// parent shell so it redraws its prompt underneath the message.
+	// Setsid puts it in its own session group so it survives kill-server.
+	cmd := exec.Command("sh", "-c", fmt.Sprintf(
+		`sleep 0.2 && printf '\n%%s\n' %q > %q && tmux kill-server 2>/dev/null; kill -WINCH %s 2>/dev/null`,
+		msg, tty, pid,
+	))
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("spawning farewell process: %w", err)
 	}
 
 	return nil
+}
+
+func resolveMessage(flag, cfg string) string {
+	if flag != "" {
+		return flag
+	}
+	if cfg != "" {
+		return cfg
+	}
+	return defaultMsg
 }

--- a/internal/tysm/tysm.go
+++ b/internal/tysm/tysm.go
@@ -12,7 +12,7 @@ import (
 
 const Usage = `usage: twin tysm [--message <text> | -m <text>]
 
-teardown: kill the tmux server and print a farewell message.
+kill the tmux server and print a farewell message.
   --message, -m custom farewell message
 `
 


### PR DESCRIPTION
## Summary
- Detach the tmux client before killing the server so the parent shell exits cleanly (no more `exit status 1`)
- Spawn a detached background process that prints the farewell message to the parent terminal's TTY, kills the server, and sends SIGWINCH to trigger a prompt redraw
- Adds `ClientTTY`, `ClientPID`, and `DetachClient` helpers to the tmux package

Closes #34

## Test plan
- [x] Run `twin tysm` inside tmux — should detach, print farewell on own line, kill server
- [x] Run `twin tysm` outside tmux — should kill server and print farewell normally
- [x] Run `twin tysm -m "custom"` — custom message in both contexts
- [x] Verify parent shell prompt redraws cleanly after the farewell message

🤖 Generated with [Claude Code](https://claude.com/claude-code)