### PR TITLE
feat(pbqt): graceful session killer

### DIFF
--- a/cmd/twin/main.go
+++ b/cmd/twin/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Josef-Hlink/twin/internal/fr"
 	"github.com/Josef-Hlink/twin/internal/icl"
+	"github.com/Josef-Hlink/twin/internal/pbqt"
 	"github.com/Josef-Hlink/twin/internal/shkspr"
 	"github.com/Josef-Hlink/twin/internal/sybau"
 	"github.com/Josef-Hlink/twin/internal/tspmo"
@@ -31,6 +32,10 @@ func main() {
 		err = fr.RunPicker()
 	case "sybau-picker":
 		err = sybau.RunPicker(os.Args[2:])
+	case "pbqt":
+		err = pbqt.Run(os.Args[2:])
+	case "pbqt-picker":
+		err = pbqt.RunPicker()
 	case "icl":
 		err = icl.Run()
 	case "icl-view":
@@ -57,6 +62,7 @@ commands:
   tspmo    spin up tmux sessions from recipes
   fr       open a single recipe (fzf picker / name / --list)
   sybau    fzf-based session switcher
+  pbqt     kill a tmux session (fzf picker / name)
   icl      quick-glance at running Claude agent panes
   shkspr   open twin.toml in $EDITOR
 `

--- a/internal/pbqt/pbqt.go
+++ b/internal/pbqt/pbqt.go
@@ -1,0 +1,172 @@
+package pbqt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Josef-Hlink/twin/internal/config"
+	"github.com/Josef-Hlink/twin/internal/popup"
+	"github.com/Josef-Hlink/twin/internal/tmux"
+	"github.com/Josef-Hlink/twin/internal/tysm"
+)
+
+const borderStyle = "fg=red bold"
+
+// Run kills a tmux session by name or launches a popup picker.
+func Run(args []string) error {
+	if len(args) > 0 {
+		return kill(args[0])
+	}
+	return pick()
+}
+
+// RunPicker runs inside the tmux popup spawned by pick.
+// It lists sessions, lets the user pick one via fzf, and kills it.
+func RunPicker() error {
+	sessions, err := tmux.ListSessions()
+	if err != nil {
+		return fmt.Errorf("listing sessions: %w", err)
+	}
+	if len(sessions) == 0 {
+		fmt.Println("no tmux sessions running")
+		return nil
+	}
+
+	current, _ := tmux.CurrentSession()
+	numbered := showNumbers()
+	lines := buildLines(sessions, current, numbered)
+
+	selected, err := popup.FzfSelect(lines, 0, "")
+	if err != nil {
+		return fmt.Errorf("fzf: %w", err)
+	}
+	if selected == "" {
+		return nil
+	}
+
+	name := stripDecorations(selected, numbered)
+	return kill(name)
+}
+
+// pick shows a picker of running sessions.
+// Inside tmux it uses a popup; outside it falls back to inline fzf.
+func pick() error {
+	sessions, err := tmux.ListSessions()
+	if err != nil {
+		return fmt.Errorf("listing sessions: %w", err)
+	}
+	if len(sessions) == 0 {
+		fmt.Println("no tmux sessions running")
+		return nil
+	}
+
+	if tmux.InTmux() {
+		return pickPopup(sessions)
+	}
+	return pickInline(sessions)
+}
+
+// pickPopup launches a tmux popup with the pbqt-picker subcommand.
+func pickPopup(sessions []string) error {
+	current, _ := tmux.CurrentSession()
+	numbered := showNumbers()
+	lines := buildLines(sessions, current, numbered)
+
+	maxLine := len("pbqt") // minimum width
+	for _, line := range lines {
+		if len(line) > maxLine {
+			maxLine = len(line)
+		}
+	}
+
+	width, height := popup.Dims(len(lines), maxLine, 0, 0, false)
+	return popup.LaunchWithStyle("pbqt", width, height, "pbqt-picker", borderStyle)
+}
+
+// pickInline shows an inline fzf picker (fallback for outside tmux).
+func pickInline(sessions []string) error {
+	numbered := showNumbers()
+	lines := buildLines(sessions, "", numbered)
+
+	selected, err := popup.FzfSelect(lines, 0, "")
+	if err != nil {
+		return fmt.Errorf("fzf: %w", err)
+	}
+	if selected == "" {
+		return nil
+	}
+
+	name := stripDecorations(selected, numbered)
+	return kill(name)
+}
+
+// kill terminates a tmux session, handling the current-session case gracefully.
+func kill(name string) error {
+	if !tmux.HasSession(name) {
+		return fmt.Errorf("session %q does not exist", name)
+	}
+
+	current, _ := tmux.CurrentSession()
+
+	if name == current {
+		sessions, err := tmux.ListSessions()
+		if err != nil {
+			return fmt.Errorf("listing sessions: %w", err)
+		}
+
+		// Last session — full teardown via tysm.
+		if len(sessions) == 1 {
+			return tysm.Run([]string{})
+		}
+
+		// Pick another session to switch to before killing.
+		for _, s := range sessions {
+			if s != name {
+				if err := tmux.SwitchClient(s); err != nil {
+					return fmt.Errorf("switching away from %s: %w", name, err)
+				}
+				break
+			}
+		}
+	}
+
+	return tmux.KillSession(name)
+}
+
+// buildLines creates display lines for the picker, marking the current
+// session with " *" and optionally prefixing with "[N] " numbers.
+func buildLines(sessions []string, current string, numbered bool) []string {
+	lines := make([]string, 0, len(sessions))
+	for i, s := range sessions {
+		line := s
+		if s == current {
+			line += " *"
+		}
+		if numbered {
+			line = fmt.Sprintf("[%d] %s", i, line)
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// stripDecorations removes the "[N] " prefix and " *" suffix from a picker line,
+// returning the bare session name.
+func stripDecorations(selected string, numbered bool) string {
+	if numbered {
+		if _, after, ok := strings.Cut(selected, "] "); ok {
+			selected = after
+		}
+	}
+	selected = strings.TrimSuffix(selected, " *")
+	return selected
+}
+
+// showNumbers returns true if session numbers should be displayed.
+func showNumbers() bool {
+	cfg, err := config.Load()
+	if err != nil {
+		return false
+	}
+	return cfg.IsOrderedSessions()
+}

--- a/internal/popup/popup.go
+++ b/internal/popup/popup.go
@@ -29,15 +29,20 @@ func Dims(itemCount, maxItemLine, maxPreviewLine, maxPreviewCount int, preview b
 	return width, height
 }
 
-// Launch opens a tmux popup running the given subcommand.
-// It resolves the executable path automatically since the popup shell
-// doesn't inherit PATH context.
+// Launch opens a tmux popup running the given subcommand with the default
+// border style. It resolves the executable path automatically since the
+// popup shell doesn't inherit PATH context.
 func Launch(title string, width, height int, subcommand string) error {
+	return LaunchWithStyle(title, width, height, subcommand, borderStyle)
+}
+
+// LaunchWithStyle opens a tmux popup with a custom border style.
+func LaunchWithStyle(title string, width, height int, subcommand, style string) error {
 	self, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolving executable path: %w", err)
 	}
-	return tmux.DisplayPopup(tmux.PopupTopLeft, title, width, height, borderStyle, self+" "+subcommand)
+	return tmux.DisplayPopup(tmux.PopupTopLeft, title, width, height, style, self+" "+subcommand)
 }
 
 // FzfSelect pipes items to fzf and returns the selected line.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -206,6 +206,11 @@ func ClientSize() (width, height int, err error) {
 	return w, h, nil
 }
 
+// KillSession kills a single tmux session by name.
+func KillSession(name string) error {
+	return exec.Command("tmux", "kill-session", "-t", name).Run()
+}
+
 // KillServer kills the tmux server, terminating all sessions.
 func KillServer() error {
 	return exec.Command("tmux", "kill-server").Run()


### PR DESCRIPTION
## Summary
- Add `twin pbqt` subcommand — kill tmux sessions via fzf popup picker or by name
- Gracefully handles killing the current session (switches client first, or falls back to `tysm` if it's the last one)
- Popup uses a red border style to distinguish from other pickers
- Adds `KillSession` to tmux wrapper and `LaunchWithStyle` to popup helpers

Closes #30

## Test plan
- [ ] `twin pbqt` — opens popup picker, selecting a session kills it
- [ ] `twin pbqt <name>` — kills the named session directly
- [ ] Kill current session with others running — switches to another session first
- [ ] Kill last remaining session — triggers `tysm` teardown
- [ ] `twin pbqt nonexistent` — errors with "does not exist"
- [ ] Run outside tmux — falls back to inline fzf

🤖 Generated with [Claude Code](https://claude.com/claude-code)