### PR TITLE
feat(tspmo): smoother spinner and color output

### DIFF
--- a/internal/tspmo/spinner.go
+++ b/internal/tspmo/spinner.go
@@ -18,6 +18,17 @@ const (
 
 var frames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
+const (
+	cReset  = "\033[0m"
+	cGreen  = "\033[32m"
+	cCyan   = "\033[36m"
+	cPurple = "\033[35m"
+)
+
+func paint(c, s string) string {
+	return c + s + cReset
+}
+
 type line struct {
 	name   string
 	status status
@@ -142,15 +153,16 @@ func (p *progress) render() {
 	for _, l := range p.lines {
 		seq++
 		prefix := fmt.Sprintf("[%d/%d]", seq, p.total)
+		name := paint(cPurple, l.name)
 		switch l.status {
 		case pending:
-			fmt.Printf("\033[2K%s %s …\n", prefix, l.name)
+			fmt.Printf("\033[2K%s %s …\n", prefix, name)
 		case active:
-			fmt.Printf("\033[2K%s %s %s\n", prefix, l.name, frames[p.frame])
+			fmt.Printf("\033[2K%s %s %s\n", prefix, name, paint(cCyan, frames[p.frame]))
 		case done:
-			fmt.Printf("\033[2K%s %s ✓\n", prefix, l.name)
+			fmt.Printf("\033[2K%s %s %s\n", prefix, name, paint(cGreen, "✓"))
 		case skipped:
-			fmt.Printf("\033[2K%s %s ✓ (already exists)\n", prefix, l.name)
+			fmt.Printf("\033[2K%s %s %s (already exists)\n", prefix, name, paint(cGreen, "✓"))
 		}
 	}
 }

--- a/internal/tspmo/tspmo.go
+++ b/internal/tspmo/tspmo.go
@@ -42,13 +42,15 @@ func Run() error {
 			continue
 		}
 
+		// Mark active before the inter-session delay so the spinner animates
+		// during the wait, not just during the brief CreateSession call.
+		p.start(name)
+
 		// Sleep before creating the next session so tmux assigns distinct
 		// creation timestamps, preserving the order from the active list.
 		if ordered && created > 0 {
 			time.Sleep(1 * time.Second)
 		}
-
-		p.start(name)
 
 		if err := CreateSession(name, recipe); err != nil {
 			fmt.Fprintf(os.Stderr, "error creating %s: %v\n", name, err)


### PR DESCRIPTION
## Summary
- **Spinner fix (closes #33):** the 1s `ordered-sessions` sleep ran before `p.start(name)`, so the upcoming line stayed in `pending` ("…") with no animation during the wait. Once `start()` flipped it to `active`, `CreateSession` resolved almost immediately — producing the "brief flash, then ✓" symptom. Fix: call `p.start(name)` above the sleep so the line is `active` (and animated by the spin goroutine) for the entire delay.
- **Colors:** purple session names, cyan spinner, green checkmark. TTY only — the non-TTY `markDone`/`skip` paths still print plain text for logs/pipes.

Closes #33

## Test plan
- [x] Mixed config (existing + new sessions): existing skip instantly with green ✓; new ones animate cyan spinner through the full 1s delay before resolving to green ✓.
- [x] First real spawn (no preceding delay) still behaves correctly.
- [x] Session names render purple in all states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)