### PR TITLE
feat(cli): recognize -h/--help on subcommands

### DIFF
--- a/cmd/twin/main.go
+++ b/cmd/twin/main.go
@@ -13,27 +13,51 @@ import (
 	"github.com/Josef-Hlink/twin/internal/tysm"
 )
 
+var helps = map[string]string{
+	"tspmo":  tspmo.Usage,
+	"fr":     fr.Usage,
+	"sybau":  sybau.Usage,
+	"pbqt":   pbqt.Usage,
+	"icl":    icl.Usage,
+	"shkspr": shkspr.Usage,
+	"tysm":   tysm.Usage,
+}
+
 func main() {
 	if len(os.Args) < 2 {
-		printUsage()
+		printUsage(os.Stderr)
 		os.Exit(1)
+	}
+
+	sub := os.Args[1]
+	args := os.Args[2:]
+
+	if sub == "-h" || sub == "--help" {
+		printUsage(os.Stdout)
+		return
+	}
+	if wantsHelp(args) {
+		if u, ok := helps[sub]; ok {
+			fmt.Print(u)
+			return
+		}
 	}
 
 	var err error
 
-	switch os.Args[1] {
+	switch sub {
 	case "tspmo":
 		err = tspmo.Run()
 	case "fr":
-		err = fr.Run(os.Args[2:])
+		err = fr.Run(args)
 	case "sybau":
-		err = sybau.Run(os.Args[2:])
+		err = sybau.Run(args)
 	case "fr-picker":
 		err = fr.RunPicker()
 	case "sybau-picker":
-		err = sybau.RunPicker(os.Args[2:])
+		err = sybau.RunPicker(args)
 	case "pbqt":
-		err = pbqt.Run(os.Args[2:])
+		err = pbqt.Run(args)
 	case "pbqt-picker":
 		err = pbqt.RunPicker()
 	case "icl":
@@ -41,22 +65,31 @@ func main() {
 	case "icl-view":
 		err = icl.RunView()
 	case "tysm":
-		err = tysm.Run(os.Args[2:])
+		err = tysm.Run(args)
 	case "shkspr":
-		err = shkspr.Run(os.Args[2:])
+		err = shkspr.Run(args)
 	default:
-		printUsage()
+		printUsage(os.Stderr)
 		os.Exit(1)
 	}
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "twin %s: %v\n", os.Args[1], err)
+		fmt.Fprintf(os.Stderr, "twin %s: %v\n", sub, err)
 		os.Exit(1)
 	}
 }
 
-func printUsage() {
-	const usage = `usage: twin <command>
+func wantsHelp(args []string) bool {
+	for _, a := range args {
+		if a == "-h" || a == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+func printUsage(w *os.File) {
+	const usage = `usage: twin <command> [args]
 
 commands:
   tspmo    spin up tmux sessions from recipes
@@ -65,6 +98,9 @@ commands:
   pbqt     kill a tmux session (fzf picker / name)
   icl      quick-glance at running Claude agent panes
   shkspr   open twin.toml in $EDITOR
+  tysm     teardown: kill the tmux server
+
+run 'twin <command> --help' for command-specific help.
 `
-	fmt.Fprint(os.Stderr, usage)
+	fmt.Fprint(w, usage)
 }

--- a/internal/fr/fr.go
+++ b/internal/fr/fr.go
@@ -12,6 +12,15 @@ import (
 	"github.com/Josef-Hlink/twin/internal/tspmo"
 )
 
+const Usage = `usage: twin fr [name | --list] [--no-attach]
+
+open a single tmux session from a recipe.
+  (no args)     fzf picker of recipes without an open session
+  <name>        open the named recipe (or attach if it already exists)
+  --list        print all available recipe names
+  --no-attach   don't auto-attach after creating the session
+`
+
 // Run opens a single tmux session from a recipe.
 // With no args it launches a popup picker (or inline fzf outside tmux);
 // with a name arg it opens directly and auto-attaches;

--- a/internal/icl/icl.go
+++ b/internal/icl/icl.go
@@ -21,6 +21,15 @@ type claudePane struct {
 	state   byte   // '*' busy, '&' menu, '-' idle
 }
 
+const Usage = `usage: twin icl
+
+interactive tabbed quickview of running claude agent panes.
+  H / left      previous tab
+  L / right     next tab
+  Enter         switch to the selected pane
+  q / Esc       close
+`
+
 // Run spawns a centered tmux popup showing the interactive Claude quickview.
 func Run() error {
 	panes, err := findClaudePanes()

--- a/internal/pbqt/pbqt.go
+++ b/internal/pbqt/pbqt.go
@@ -12,6 +12,15 @@ import (
 
 const borderStyle = "fg=red bold"
 
+const Usage = `usage: twin pbqt [name]
+
+kill a tmux session.
+  (no args)     fzf popup picker of running sessions
+  <name>        kill the named session directly
+killing the current session switches away first, or falls back to tysm
+if it's the last session.
+`
+
 // Run kills a tmux session by name or launches a popup picker.
 func Run(args []string) error {
 	if len(args) > 0 {

--- a/internal/shkspr/shkspr.go
+++ b/internal/shkspr/shkspr.go
@@ -9,6 +9,12 @@ import (
 	"github.com/Josef-Hlink/twin/internal/config"
 )
 
+const Usage = `usage: twin shkspr [--recipes | -r]
+
+open twin.toml in $EDITOR (or vim/nano if unset).
+  --recipes, -r open the recipes directory instead of twin.toml
+`
+
 // Run opens the twin.toml config file or the recipes directory in the
 // user's editor.
 func Run(args []string) error {

--- a/internal/sybau/sybau.go
+++ b/internal/sybau/sybau.go
@@ -10,6 +10,12 @@ import (
 	"github.com/Josef-Hlink/twin/internal/tmux"
 )
 
+const Usage = `usage: twin sybau [--preview]
+
+fzf-based session switcher in a tmux popup.
+  --preview     show each session's windows in a right-side preview pane
+`
+
 // Run launches a tmux popup containing the fzf session picker.
 func Run(args []string) error {
 	preview := slices.Contains(args, "--preview")

--- a/internal/tspmo/tspmo.go
+++ b/internal/tspmo/tspmo.go
@@ -13,6 +13,13 @@ import (
 	"github.com/Josef-Hlink/twin/internal/tmux"
 )
 
+const Usage = `usage: twin tspmo
+
+spin up tmux sessions from active recipes in twin.toml.
+sessions whose name already exists are skipped (✓ already exists).
+attaches to auto-attach-to from config, or prompts otherwise.
+`
+
 // Run loads the config, reads active recipes, and creates tmux sessions.
 func Run() error {
 	cfg, err := config.Load()

--- a/internal/tysm/tysm.go
+++ b/internal/tysm/tysm.go
@@ -7,6 +7,13 @@ import (
 	"github.com/Josef-Hlink/twin/internal/tmux"
 )
 
+const Usage = `usage: twin tysm [--message <text> | -m <text>]
+
+teardown: kill the tmux server and print a farewell message.
+message precedence: --message flag > tysm-msg in config > default.
+  --message, -m custom farewell message
+`
+
 // Run loads the config, and just kills the tmux server.
 func Run(args []string) error {
 	fs := flag.NewFlagSet("tysm", flag.ContinueOnError)

--- a/internal/tysm/tysm.go
+++ b/internal/tysm/tysm.go
@@ -10,7 +10,6 @@ import (
 const Usage = `usage: twin tysm [--message <text> | -m <text>]
 
 teardown: kill the tmux server and print a farewell message.
-message precedence: --message flag > tysm-msg in config > default.
   --message, -m custom farewell message
 `
 


### PR DESCRIPTION
## Summary
- Each user-facing package (`tspmo`, `fr`, `sybau`, `pbqt`, `icl`, `shkspr`, `tysm`) exports a `Usage` const describing the command and its flags.
- `main.go` scans args for `-h`/`--help` before dispatching, prints the matching subcommand's usage to stdout, exits 0.
- Top-level `twin -h` / `twin --help` prints the existing top-level usage to stdout (the no-args / unknown-command path still goes to stderr with exit 1).
- Internal pickers (`fr-picker`, `sybau-picker`, `pbqt-picker`, `icl-view`) are deliberately not wired up — they're not user-facing.

## Drive-bys
- `twin fr --help` no longer tries to open a recipe named `--help`.
- `twin pbqt --help` no longer tries to kill a session named `--help`.
- `tysm` was missing from the top-level command list; added.

Closes #22

## Test plan
- [x] `twin --help` / `twin -h` → top-level usage on stdout
- [x] `twin <cmd> --help` / `twin <cmd> -h` for each of the 7 user-facing subcommands → command-specific usage on stdout
- [x] `twin nonexistent` → top-level usage on stderr, exit 1
- [x] `twin fr --list` (real flag) still works
- [ ] `twin sybau --preview` still launches the popup
- [ ] `twin tspmo` still spins up sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)