### PR TITLE
feat(popup): configurable border + fzf accent colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ active = ["front", "back", "infra"]
 
 `active` controls which recipes `twin tspmo` spins up.
 
+### Popup colors
+
+Each subcommand that uses a popup picker (`fr`, `sybau`, `pbqt`, `icl`) has a configurable accent color that paints both the tmux popup border and fzf's pointer/marker, so the picker reads as one themed surface.
+
+```toml
+fr-border-color    = "green"      # default: green
+sybau-border-color = "magenta"    # default: magenta
+pbqt-border-color  = "red"        # default: red
+icl-border-color   = "colour214"  # default: colour214 (orange)
+```
+
+Values accept any form both tools take: a named color (`red`, `magenta`, `cyan`, …), a 256-color index (`214` or `colour214`), or hex (`#ff8800`).
+
 ## Recipes
 
 Each recipe is a TOML file in the recipe directory. The filename becomes the session name.

--- a/internal/config/color.go
+++ b/internal/config/color.go
@@ -1,0 +1,36 @@
+package config
+
+import "strings"
+
+// Color is a terminal color reference. The string value is the user-facing
+// form: a named color ("red", "magenta"), a 256-color index ("214" or
+// "colour214"), or a hex literal ("#ff8800"). Tmux() and Fzf() return the
+// representation each tool expects, since they spell digit-only colors
+// differently (tmux: "colour214", fzf: "214").
+type Color string
+
+// Tmux returns the tmux-style color fragment (e.g. "magenta" or "colour214").
+func (c Color) Tmux() string {
+	s := string(c)
+	if isAllDigits(s) {
+		return "colour" + s
+	}
+	return s
+}
+
+// Fzf returns the fzf-style color fragment (e.g. "magenta" or "214").
+func (c Color) Fzf() string {
+	return strings.TrimPrefix(string(c), "colour")
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,11 +11,15 @@ import (
 
 // Config represents the top-level twin.toml file.
 type Config struct {
-	RecipeDir       string   `toml:"recipe-dir"`
-	Active          []string `toml:"active"`
-	OrderedSessions *bool    `toml:"ordered-sessions"`
-	AutoAttachTo    string   `toml:"auto-attach-to"`
-	TysmMsg         string   `toml:"tysm-msg"`
+	RecipeDir        string   `toml:"recipe-dir"`
+	Active           []string `toml:"active"`
+	OrderedSessions  *bool    `toml:"ordered-sessions"`
+	AutoAttachTo     string   `toml:"auto-attach-to"`
+	TysmMsg          string   `toml:"tysm-msg"`
+	FrBorderColor    string   `toml:"fr-border-color"`
+	SybauBorderColor string   `toml:"sybau-border-color"`
+	PbqtBorderColor  string   `toml:"pbqt-border-color"`
+	IclBorderColor   string   `toml:"icl-border-color"`
 }
 
 // IsOrderedSessions returns whether sessions should be created with delays
@@ -25,6 +29,28 @@ func (c Config) IsOrderedSessions() bool {
 		return true
 	}
 	return *c.OrderedSessions
+}
+
+// BorderColor returns the popup border + fzf accent color for the given
+// subcommand, falling back to the per-command default when unset.
+func (c Config) BorderColor(cmd string) Color {
+	var raw, def string
+	switch cmd {
+	case "fr":
+		raw, def = c.FrBorderColor, "green"
+	case "sybau":
+		raw, def = c.SybauBorderColor, "magenta"
+	case "pbqt":
+		raw, def = c.PbqtBorderColor, "red"
+	case "icl":
+		raw, def = c.IclBorderColor, "colour214"
+	default:
+		return Color("magenta")
+	}
+	if raw == "" {
+		return Color(def)
+	}
+	return Color(raw)
 }
 
 // Window represents a single window in a recipe.

--- a/internal/fr/fr.go
+++ b/internal/fr/fr.go
@@ -128,14 +128,15 @@ func pick() error {
 		return nil
 	}
 
+	color := cfg.BorderColor("fr")
 	if tmux.InTmux() {
-		return pickPopup(available)
+		return pickPopup(available, color)
 	}
-	return pickInline(available)
+	return pickInline(available, color)
 }
 
 // pickPopup launches a tmux popup with the fr-picker subcommand.
-func pickPopup(available []string) error {
+func pickPopup(available []string, color config.Color) error {
 	maxLine := len("fr") // minimum width
 	for _, name := range available {
 		if len(name) > maxLine {
@@ -144,12 +145,12 @@ func pickPopup(available []string) error {
 	}
 
 	width, height := popup.Dims(len(available), maxLine, 0, 0, false)
-	return popup.Launch("fr", width, height, "fr-picker")
+	return popup.Launch("fr", width, height, "fr-picker", color)
 }
 
 // pickInline shows an inline fzf picker (fallback for outside tmux).
-func pickInline(available []string) error {
-	selected, err := popup.FzfSelect(available, 0, "")
+func pickInline(available []string, color config.Color) error {
+	selected, err := popup.FzfSelect(available, 0, "", color)
 	if err != nil {
 		return fmt.Errorf("fzf: %w", err)
 	}
@@ -185,7 +186,7 @@ func RunPicker() error {
 		return nil
 	}
 
-	selected, err := popup.FzfSelect(available, 0, "")
+	selected, err := popup.FzfSelect(available, 0, "", cfg.BorderColor("fr"))
 	if err != nil {
 		return fmt.Errorf("fzf: %w", err)
 	}

--- a/internal/icl/icl.go
+++ b/internal/icl/icl.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/Josef-Hlink/twin/internal/config"
+	"github.com/Josef-Hlink/twin/internal/popup"
 	"github.com/Josef-Hlink/twin/internal/tmux"
 )
 
@@ -41,9 +43,9 @@ func Run() error {
 		return nil
 	}
 
-	self, err := os.Executable()
+	cfg, err := config.Load()
 	if err != nil {
-		return fmt.Errorf("resolving executable path: %w", err)
+		return err
 	}
 
 	clientW, clientH, _ := tmux.ClientSize()
@@ -56,7 +58,7 @@ func Run() error {
 		height = 10
 	}
 
-	return tmux.DisplayPopup(tmux.PopupCenter, "icl", width, height, "fg=colour214,bold", self+" icl-view")
+	return popup.LaunchCenter("icl", width, height, "icl-view", cfg.BorderColor("icl"))
 }
 
 // RunView renders the interactive tabbed Claude pane viewer. Runs inside the popup.

--- a/internal/pbqt/pbqt.go
+++ b/internal/pbqt/pbqt.go
@@ -10,8 +10,6 @@ import (
 	"github.com/Josef-Hlink/twin/internal/tysm"
 )
 
-const borderStyle = "fg=red bold"
-
 const Usage = `usage: twin pbqt [name]
 
 kill a tmux session.
@@ -32,6 +30,11 @@ func Run(args []string) error {
 // RunPicker runs inside the tmux popup spawned by pick.
 // It lists sessions, lets the user pick one via fzf, and kills it.
 func RunPicker() error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
 	sessions, err := tmux.ListSessions()
 	if err != nil {
 		return fmt.Errorf("listing sessions: %w", err)
@@ -42,10 +45,10 @@ func RunPicker() error {
 	}
 
 	current, _ := tmux.CurrentSession()
-	numbered := showNumbers()
+	numbered := cfg.IsOrderedSessions()
 	lines := buildLines(sessions, current, numbered)
 
-	selected, err := popup.FzfSelect(lines, 0, "")
+	selected, err := popup.FzfSelect(lines, 0, "", cfg.BorderColor("pbqt"))
 	if err != nil {
 		return fmt.Errorf("fzf: %w", err)
 	}
@@ -60,6 +63,11 @@ func RunPicker() error {
 // pick shows a picker of running sessions.
 // Inside tmux it uses a popup; outside it falls back to inline fzf.
 func pick() error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
 	sessions, err := tmux.ListSessions()
 	if err != nil {
 		return fmt.Errorf("listing sessions: %w", err)
@@ -69,16 +77,17 @@ func pick() error {
 		return nil
 	}
 
+	color := cfg.BorderColor("pbqt")
+	numbered := cfg.IsOrderedSessions()
 	if tmux.InTmux() {
-		return pickPopup(sessions)
+		return pickPopup(sessions, color, numbered)
 	}
-	return pickInline(sessions)
+	return pickInline(sessions, color, numbered)
 }
 
 // pickPopup launches a tmux popup with the pbqt-picker subcommand.
-func pickPopup(sessions []string) error {
+func pickPopup(sessions []string, color config.Color, numbered bool) error {
 	current, _ := tmux.CurrentSession()
-	numbered := showNumbers()
 	lines := buildLines(sessions, current, numbered)
 
 	maxLine := len("pbqt") // minimum width
@@ -89,15 +98,14 @@ func pickPopup(sessions []string) error {
 	}
 
 	width, height := popup.Dims(len(lines), maxLine, 0, 0, false)
-	return popup.LaunchWithStyle("pbqt", width, height, "pbqt-picker", borderStyle)
+	return popup.Launch("pbqt", width, height, "pbqt-picker", color)
 }
 
 // pickInline shows an inline fzf picker (fallback for outside tmux).
-func pickInline(sessions []string) error {
-	numbered := showNumbers()
+func pickInline(sessions []string, color config.Color, numbered bool) error {
 	lines := buildLines(sessions, "", numbered)
 
-	selected, err := popup.FzfSelect(lines, 0, "")
+	selected, err := popup.FzfSelect(lines, 0, "", color)
 	if err != nil {
 		return fmt.Errorf("fzf: %w", err)
 	}
@@ -171,11 +179,3 @@ func stripDecorations(selected string, numbered bool) string {
 	return selected
 }
 
-// showNumbers returns true if session numbers should be displayed.
-func showNumbers() bool {
-	cfg, err := config.Load()
-	if err != nil {
-		return false
-	}
-	return cfg.IsOrderedSessions()
-}

--- a/internal/popup/popup.go
+++ b/internal/popup/popup.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/Josef-Hlink/twin/internal/config"
 	"github.com/Josef-Hlink/twin/internal/tmux"
 )
 
@@ -13,7 +14,6 @@ const (
 	chromeWidth       = 5 // fzf prompt + padding + tmux popup border (left/right)
 	chromeHeight      = 4 // fzf prompt + status + tmux popup border (top/bottom)
 	previewExtraWidth = 3 // preview border-left + padding
-	borderStyle       = "fg=magenta bold"
 )
 
 // Dims computes popup width and height from content metrics.
@@ -29,26 +29,35 @@ func Dims(itemCount, maxItemLine, maxPreviewLine, maxPreviewCount int, preview b
 	return width, height
 }
 
-// Launch opens a tmux popup running the given subcommand with the default
-// border style. It resolves the executable path automatically since the
-// popup shell doesn't inherit PATH context.
-func Launch(title string, width, height int, subcommand string) error {
-	return LaunchWithStyle(title, width, height, subcommand, borderStyle)
+// Launch opens a tmux popup at the top-left running the given subcommand,
+// with the border styled in `color`.
+func Launch(title string, width, height int, subcommand string, color config.Color) error {
+	return launch(tmux.PopupTopLeft, title, width, height, subcommand, color)
 }
 
-// LaunchWithStyle opens a tmux popup with a custom border style.
-func LaunchWithStyle(title string, width, height int, subcommand, style string) error {
+// LaunchCenter opens a tmux popup centered on screen.
+func LaunchCenter(title string, width, height int, subcommand string, color config.Color) error {
+	return launch(tmux.PopupCenter, title, width, height, subcommand, color)
+}
+
+func launch(anchor tmux.PopupAnchor, title string, width, height int, subcommand string, color config.Color) error {
 	self, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolving executable path: %w", err)
 	}
-	return tmux.DisplayPopup(tmux.PopupTopLeft, title, width, height, style, self+" "+subcommand)
+	style := fmt.Sprintf("fg=%s bold", color.Tmux())
+	return tmux.DisplayPopup(anchor, title, width, height, style, self+" "+subcommand)
 }
 
 // FzfSelect pipes items to fzf and returns the selected line.
 // When previewCols > 0 and previewCmd is non-empty, a preview pane is shown.
-func FzfSelect(items []string, previewCols int, previewCmd string) (string, error) {
+// When accent is non-empty, fzf's pointer + marker are colored to match.
+func FzfSelect(items []string, previewCols int, previewCmd string, accent config.Color) (string, error) {
 	var fzfArgs []string
+	if accent != "" {
+		c := accent.Fzf()
+		fzfArgs = append(fzfArgs, "--color", fmt.Sprintf("pointer:%s,marker:%s", c, c))
+	}
 	if previewCols > 0 && previewCmd != "" {
 		fzfArgs = append(fzfArgs,
 			"--preview", previewCmd,

--- a/internal/sybau/sybau.go
+++ b/internal/sybau/sybau.go
@@ -20,13 +20,18 @@ fzf-based session switcher in a tmux popup.
 func Run(args []string) error {
 	preview := slices.Contains(args, "--preview")
 
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
 	sessions, err := tmux.ListSessions()
 	if err != nil {
 		return fmt.Errorf("listing sessions: %w", err)
 	}
 
 	current, _ := tmux.CurrentSession()
-	numbered := showNumbers()
+	numbered := cfg.IsOrderedSessions()
 
 	// Calculate popup dimensions from actual content, skipping the current session.
 	count := 0
@@ -61,7 +66,7 @@ func Run(args []string) error {
 	if preview {
 		cmd += " --preview"
 	}
-	return popup.Launch("sybau", width, height, cmd)
+	return popup.Launch("sybau", width, height, cmd, cfg.BorderColor("sybau"))
 }
 
 // RunPicker lists tmux sessions, lets the user pick one via fzf, and switches to it.
@@ -69,13 +74,18 @@ func Run(args []string) error {
 func RunPicker(args []string) error {
 	preview := slices.Contains(args, "--preview")
 
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
 	sessions, err := tmux.ListSessions()
 	if err != nil {
 		return fmt.Errorf("listing sessions: %w", err)
 	}
 
 	current, _ := tmux.CurrentSession()
-	numbered := showNumbers()
+	numbered := cfg.IsOrderedSessions()
 
 	// Build display lines with original indices, skipping the current session.
 	var lines []string
@@ -105,7 +115,7 @@ func RunPicker(args []string) error {
 		previewCmd = `tmux list-windows -t "$(echo {} | sed 's/^\[.*\] //')" -F '#{window_active} #{window_index}:#{window_name}#{window_flags}' | awk '{if($1=="1"){printf "\033[1;36m%s\033[0m\n",substr($0,3)}else{print substr($0,3)}}'`
 	}
 
-	selected, err := popup.FzfSelect(lines, previewCols, previewCmd)
+	selected, err := popup.FzfSelect(lines, previewCols, previewCmd, cfg.BorderColor("sybau"))
 	if err != nil {
 		return fmt.Errorf("fzf: %w", err)
 	}
@@ -146,13 +156,3 @@ func windowMetrics(sessions []string, skip string) (maxLine, maxCount int) {
 	return maxLine, maxCount
 }
 
-// showNumbers returns true if session numbers should be displayed in the picker.
-// This is tied to the ordered-sessions config option — numbers only make sense
-// when sessions have a meaningful order.
-func showNumbers() bool {
-	cfg, err := config.Load()
-	if err != nil {
-		return false
-	}
-	return cfg.IsOrderedSessions()
-}


### PR DESCRIPTION
## Summary
- Adds 4 config keys: `fr-border-color`, `sybau-border-color`, `pbqt-border-color`, `icl-border-color`. Defaults: green / magenta / red / colour214.
- Each key paints **both** the tmux popup border *and* fzf's `pointer` + `marker`, so the picker reads as one themed surface instead of a colored frame around stock-colored fzf.
- Values accept any form both tools take: named colors (`red`, `magenta`), 256-color indices (`colour214` or `214`), and hex (`#ff8800`). The new `config.Color` type translates between tmux's `colour214` and fzf's `214` spellings.
- `popup.LaunchCenter` added so `icl` runs through the same path instead of calling `tmux.DisplayPopup` directly.
- Drive-by: removed the duplicated `showNumbers` helpers in `sybau`/`pbqt` (each already loads cfg now); removed the hardcoded `borderStyle` const in `pbqt` (it's just the `pbqt-border-color` default now).
- README documents the new keys.

Closes #36

## Notes
- "orange" is not a tmux named color, so the icl default is `colour214` (xterm 214). Hex (`#ff8800`) works too.
- Only `pointer` and `marker` get themed — your existing fzf prompt/info colors are untouched.

## Test plan
- [x] `twin sybau` — purple (magenta) border + purple pointer
- [x] `twin fr` — green border + green pointer
- [x] `twin pbqt` — red border + red pointer
- [x] `twin icl` — orange border
- [x] Override via `*-border-color` config key (named, indexed, and hex forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)