### PR TITLE
feat(frfr): scaffold a new recipe from template.toml

### DIFF
--- a/cmd/twin/main.go
+++ b/cmd/twin/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Josef-Hlink/twin/internal/fr"
+	"github.com/Josef-Hlink/twin/internal/frfr"
 	"github.com/Josef-Hlink/twin/internal/icl"
 	"github.com/Josef-Hlink/twin/internal/pbqt"
 	"github.com/Josef-Hlink/twin/internal/shkspr"
@@ -16,6 +17,7 @@ import (
 var helps = map[string]string{
 	"tspmo":  tspmo.Usage,
 	"fr":     fr.Usage,
+	"frfr":   frfr.Usage,
 	"sybau":  sybau.Usage,
 	"pbqt":   pbqt.Usage,
 	"icl":    icl.Usage,
@@ -50,6 +52,8 @@ func main() {
 		err = tspmo.Run()
 	case "fr":
 		err = fr.Run(args)
+	case "frfr":
+		err = frfr.Run(args)
 	case "sybau":
 		err = sybau.Run(args)
 	case "fr-picker":
@@ -94,6 +98,7 @@ func printUsage(w *os.File) {
 commands:
   tspmo    spin up tmux sessions from recipes
   fr       open a single recipe (fzf picker / name / --list)
+  frfr     scaffold a new recipe from template.toml and open in $EDITOR
   sybau    fzf-based session switcher
   pbqt     kill a tmux session (fzf picker / name)
   icl      quick-glance at running Claude agent panes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,7 +87,36 @@ func Load() (Config, error) {
 	}
 
 	cfg.RecipeDir = expandPath(cfg.RecipeDir)
+	ensureTemplate(cfg.RecipeDir)
 	return cfg, nil
+}
+
+// TemplatePath returns the absolute path to template.toml inside recipeDir.
+func TemplatePath(recipeDir string) string {
+	return filepath.Join(recipeDir, "template.toml")
+}
+
+// templateContent is the body of the scaffolded template.toml.
+const templateContent = `start-directory = "~/"
+
+[[windows]]
+`
+
+// ensureTemplate writes template.toml into recipeDir if it doesn't already
+// exist. Silent no-op if recipeDir is missing or the write fails — frfr will
+// surface a useful error later if the user actually tries to use the template.
+func ensureTemplate(recipeDir string) {
+	if recipeDir == "" {
+		return
+	}
+	if _, err := os.Stat(recipeDir); err != nil {
+		return
+	}
+	path := TemplatePath(recipeDir)
+	if _, err := os.Stat(path); err == nil {
+		return
+	}
+	_ = os.WriteFile(path, []byte(templateContent), 0o644)
 }
 
 // LoadRecipe reads a recipe TOML file from the recipe directory.
@@ -116,7 +145,11 @@ func ListRecipes(recipeDir string) ([]string, error) {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
 			continue
 		}
-		names = append(names, strings.TrimSuffix(e.Name(), ".toml"))
+		name := strings.TrimSuffix(e.Name(), ".toml")
+		if name == "template" {
+			continue
+		}
+		names = append(names, name)
 	}
 	return names, nil
 }
@@ -169,9 +202,10 @@ commands = ["cd ${GOPATH:-$HOME/go}/bin && ls -la twin"]
 `, configDirVar())
 
 	files := map[string]string{
-		filepath.Join(dir, "twin.toml"):       cfgContent,
-		filepath.Join(recipeDir, "home.toml"): homeRecipe,
-		filepath.Join(recipeDir, "twin.toml"): twinRecipe,
+		filepath.Join(dir, "twin.toml"):           cfgContent,
+		filepath.Join(recipeDir, "home.toml"):     homeRecipe,
+		filepath.Join(recipeDir, "twin.toml"):     twinRecipe,
+		filepath.Join(recipeDir, "template.toml"): templateContent,
 	}
 
 	for path, content := range files {

--- a/internal/frfr/frfr.go
+++ b/internal/frfr/frfr.go
@@ -1,0 +1,79 @@
+package frfr
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Josef-Hlink/twin/internal/config"
+)
+
+const Usage = `usage: twin frfr <name>
+
+scaffold a new recipe from template.toml and open it in $EDITOR.
+fails if <name>.toml already exists.
+`
+
+// Run creates a new recipe file by copying template.toml, then opens it in
+// the user's editor.
+func Run(args []string) error {
+	if len(args) != 1 {
+		fmt.Fprint(os.Stderr, Usage)
+		return fmt.Errorf("expected exactly one recipe name")
+	}
+
+	name := args[0]
+	if name == "template" {
+		return fmt.Errorf("%q is a reserved recipe name", name)
+	}
+	if strings.ContainsAny(name, "/\\") || strings.HasPrefix(name, ".") {
+		return fmt.Errorf("invalid recipe name %q", name)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	dst := filepath.Join(cfg.RecipeDir, name+".toml")
+	if _, err := os.Stat(dst); err == nil {
+		return fmt.Errorf("recipe %q already exists at %s", name, dst)
+	}
+
+	src := config.TemplatePath(cfg.RecipeDir)
+	content, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("reading template: %w", err)
+	}
+
+	if err := os.WriteFile(dst, content, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", dst, err)
+	}
+
+	editor, err := resolveEditor()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(editor, dst)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// resolveEditor returns the first available editor from:
+// $EDITOR, vim, nano.
+func resolveEditor() (string, error) {
+	if editor := os.Getenv("EDITOR"); editor != "" {
+		return editor, nil
+	}
+	for _, name := range []string{"vim", "nano"} {
+		if _, err := exec.LookPath(name); err == nil {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("no valid editor found on system (set $EDITOR)")
+}


### PR DESCRIPTION
Closes #41

## Summary
- New `twin frfr <name>` subcommand: copies `template.toml` into `<name>.toml` and opens it in `$EDITOR` (falls back to `vim`, then `nano`)
- `template.toml` is added to the initial config scaffold and lazily ensured on every `config.Load()` so existing users get it on their next twin invocation
- `config.ListRecipes` filters `template` out so `twin fr` (picker, `--list`, popup) doesn't show it as an openable recipe
- Errors cleanly on: missing/extra args, reserved name `template`, slash- or dot-prefixed names, and existing `<name>.toml` (no clobber)

## Test plan
- [ ] Fresh config (`TWIN_CONFIG_DIR=$(mktemp -d) twin frfr myproj`) — scaffolds `twin.toml`, `home.toml`, `twin.toml`, `template.toml`, then creates `myproj.toml` and opens it
- [ ] Existing config without `template.toml` — next `twin` call writes it silently
- [ ] `twin frfr` with no args — prints usage, exits 1
- [ ] `twin frfr myproj` twice in a row — second call errors, no overwrite
- [ ] `twin frfr template` — rejected as reserved
- [ ] `twin fr --list` — does not include `template`
- [ ] `twin fr` picker / popup — does not list `template`
- [ ] `twin tspmo` with an `active = ["template"]` entry — would still try to load it (active list is user-controlled and explicit; not a regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)