### PR TITLE
feat(release): GoReleaser config and Homebrew tap workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /twin
+/dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,69 @@
+version: 2
+
+project_name: twin
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: twin
+    main: ./cmd/twin
+    binary: twin
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+
+archives:
+  - id: twin
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^chore:'
+      - '^test:'
+      - Merge pull request
+      - Merge branch
+
+brews:
+  - name: twin
+    repository:
+      owner: Josef-Hlink
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/Josef-Hlink/twin
+    description: tmux workspace manager driven by TOML recipes
+    license: MIT
+    dependencies:
+      - name: tmux
+      - name: fzf
+    install: |
+      bin.install "twin"
+    test: |
+      system "#{bin}/twin", "--version"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "chore(formula): bump {{ .ProjectName }} to {{ .Tag }}"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Josef-Hlink
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/twin/main.go
+++ b/cmd/twin/main.go
@@ -14,6 +14,9 @@ import (
 	"github.com/Josef-Hlink/twin/internal/tysm"
 )
 
+// version is set at build time via ldflags by GoReleaser.
+var version = "dev"
+
 var helps = map[string]string{
 	"tspmo":  tspmo.Usage,
 	"fr":     fr.Usage,
@@ -36,6 +39,10 @@ func main() {
 
 	if sub == "-h" || sub == "--help" {
 		printUsage(os.Stdout)
+		return
+	}
+	if sub == "--version" {
+		fmt.Println(version)
 		return
 	}
 	if wantsHelp(args) {


### PR DESCRIPTION
Closes #26.

## Summary

- Adds `.goreleaser.yaml` (v2): cross-compiles for darwin/linux × amd64/arm64, archives as tar.gz with SHA256 checksums, generates Homebrew formula targeting `Josef-Hlink/homebrew-tap`.
- Adds `.github/workflows/release.yml`: triggers on `v*` tag push, runs `goreleaser release --clean`. Requires `HOMEBREW_TAP_GITHUB_TOKEN` secret (fine-grained PAT scoped to the tap repo, `Contents: Read and write`).
- Adds `LICENSE` (MIT) — required by the formula.
- Adds `--version` flag to `twin`, with `var version = "dev"` injected at build time via GoReleaser ldflags.
- Ignores `/dist/` (GoReleaser output dir).

## Verified locally

`goreleaser release --snapshot --clean` produces:
- 4 binaries (darwin/linux × amd64/arm64)
- 4 tar.gz archives + `checksums.txt`
- Valid `dist/homebrew/twin.rb` formula declaring `tmux` and `fzf` as dependencies

## Known: deprecation warning

GoReleaser v2.10+ emits a soft deprecation for the `brews` key in favor of `homebrew_casks`. Shipping with `brews` deliberately for the first release — cask migration deserves its own focused PR (Gatekeeper quarantine handling for unsigned binaries, dependency syntax changes). Hard removal is in v2.16, so we have runway.

## Test plan

- [ ] Merge this PR
- [ ] `git tag v0.1.0 && git push origin v0.1.0`
- [ ] Watch the release workflow succeed
- [ ] Verify `Josef-Hlink/homebrew-tap` gets a `Formula/twin.rb` commit
- [ ] `brew tap Josef-Hlink/tap && brew install twin && twin --version` → prints `v0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)