### PR TITLE
feat(release): publish to nix tap alongside homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           go-version: '1.25'
 
+      # nix-hash must be on PATH for goreleaser's nix pipe to compute SRI hashes
+      - uses: cachix/install-nix-action@v31
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
@@ -28,3 +31,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          NIX_TAP_GITHUB_TOKEN: ${{ secrets.NIX_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,3 +67,23 @@ brews:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "chore(formula): bump {{ .ProjectName }} to {{ .Tag }}"
+
+nix:
+  - name: twin
+    ids:
+      - twin
+    repository:
+      owner: Josef-Hlink
+      name: nur-packages
+      branch: main
+      token: "{{ .Env.NIX_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/Josef-Hlink/twin
+    description: tmux workspace manager driven by TOML recipes
+    license: mit
+    dependencies:
+      - tmux
+      - fzf
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "chore(nix): bump {{ .ProjectName }} to {{ .Tag }}"


### PR DESCRIPTION
## Summary
- Add a `nix:` block to `.goreleaser.yaml` that commits a derivation to the `nur-packages` flake on each tag, mirroring the existing homebrew tap (runtime deps: tmux, fzf).
- Install Nix in `release.yml` (`cachix/install-nix-action@v31`) so `nix-hash` is on PATH for GoReleaser's nix pipe.
- Pass `NIX_TAP_GITHUB_TOKEN` through to GoReleaser.

Enables installing twin on machines without Homebrew:

```sh
nix profile install github:Josef-Hlink/nur-packages#twin
```

Closes #44

## Test plan
- [ ] `goreleaser check` passes (verified locally)
- [ ] Cut a tag and confirm GoReleaser commits `pkgs/twin/default.nix` to `nur-packages`
- [ ] `nix run github:Josef-Hlink/nur-packages#twin -- --version` works on Linux