### PR TITLE
fix(tspmo): ensure recipe-dir exists and fail loudly

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,7 +87,9 @@ func Load() (Config, error) {
 	}
 
 	cfg.RecipeDir = expandPath(cfg.RecipeDir)
-	ensureTemplate(cfg.RecipeDir)
+	if err := ensureRecipeDir(cfg.RecipeDir); err != nil {
+		return cfg, err
+	}
 	return cfg, nil
 }
 
@@ -102,21 +104,30 @@ const templateContent = `start-directory = "~/"
 [[windows]]
 `
 
-// ensureTemplate writes template.toml into recipeDir if it doesn't already
-// exist. Silent no-op if recipeDir is missing or the write fails — frfr will
-// surface a useful error later if the user actually tries to use the template.
-func ensureTemplate(recipeDir string) {
+// ensureRecipeDir guarantees recipeDir exists and contains a template.toml,
+// creating both if missing. This is what makes twin usable when twin.toml is
+// present (e.g. symlinked from dotfiles) but the recipe-dir was never created.
+func ensureRecipeDir(recipeDir string) error {
 	if recipeDir == "" {
-		return
+		return fmt.Errorf("recipe-dir is not set in twin.toml")
 	}
-	if _, err := os.Stat(recipeDir); err != nil {
-		return
+	created := false
+	if _, err := os.Stat(recipeDir); os.IsNotExist(err) {
+		created = true
+	}
+	if err := os.MkdirAll(recipeDir, 0o755); err != nil {
+		return fmt.Errorf("creating recipe dir %s: %w", recipeDir, err)
 	}
 	path := TemplatePath(recipeDir)
-	if _, err := os.Stat(path); err == nil {
-		return
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err := os.WriteFile(path, []byte(templateContent), 0o644); err != nil {
+			return fmt.Errorf("writing template %s: %w", path, err)
+		}
 	}
-	_ = os.WriteFile(path, []byte(templateContent), 0o644)
+	if created {
+		fmt.Printf("recipe-dir %s was missing — created it with a template.toml\n", recipeDir)
+	}
+	return nil
 }
 
 // LoadRecipe reads a recipe TOML file from the recipe directory.

--- a/internal/tspmo/spinner.go
+++ b/internal/tspmo/spinner.go
@@ -14,6 +14,7 @@ const (
 	active
 	done
 	skipped
+	failed
 )
 
 var frames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -23,6 +24,7 @@ const (
 	cGreen  = "\033[32m"
 	cCyan   = "\033[36m"
 	cPurple = "\033[35m"
+	cRed    = "\033[31m"
 )
 
 func paint(c, s string) string {
@@ -32,6 +34,7 @@ func paint(c, s string) string {
 type line struct {
 	name   string
 	status status
+	note   string // failure reason, shown after halt in TTY mode
 }
 
 // progress renders real-time session creation feedback.
@@ -42,6 +45,7 @@ type progress struct {
 	lines    []line
 	total    int
 	done_    int // count of done+skipped
+	failed_  int // count of recipes that failed to start
 	isTTY    bool
 	frame    int
 	rendered bool
@@ -114,6 +118,21 @@ func (p *progress) skip(name string) {
 	}
 }
 
+func (p *progress) fail(name string, reason error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if i := p.indexOf(name); i >= 0 {
+		p.lines[i].status = failed
+		p.lines[i].note = reason.Error()
+		p.failed_++
+	}
+	if p.isTTY {
+		p.render()
+	} else {
+		fmt.Printf("[%d/%d] %s ✗ (%v)\n", p.done_+p.failed_, p.total, name, reason)
+	}
+}
+
 // halt stops the spinner goroutine and does a final render.
 func (p *progress) halt() {
 	if p.isTTY {
@@ -121,6 +140,20 @@ func (p *progress) halt() {
 		p.mu.Lock()
 		p.render()
 		p.mu.Unlock()
+	}
+}
+
+// reportFailures prints the reason for each failed recipe. Only needed in TTY
+// mode, where render() shows just a ✗ to keep the animation lines from wrapping;
+// the non-TTY path already prints reasons inline.
+func (p *progress) reportFailures() {
+	if !p.isTTY {
+		return
+	}
+	for _, l := range p.lines {
+		if l.status == failed {
+			fmt.Fprintf(os.Stderr, "%s %s: %s\n", paint(cRed, "✗"), l.name, l.note)
+		}
 	}
 }
 
@@ -163,6 +196,8 @@ func (p *progress) render() {
 			fmt.Printf("\033[2K%s %s %s\n", prefix, name, paint(cGreen, "✓"))
 		case skipped:
 			fmt.Printf("\033[2K%s %s %s (already exists)\n", prefix, name, paint(cGreen, "✓"))
+		case failed:
+			fmt.Printf("\033[2K%s %s %s\n", prefix, name, paint(cRed, "✗"))
 		}
 	}
 }

--- a/internal/tspmo/tspmo.go
+++ b/internal/tspmo/tspmo.go
@@ -45,7 +45,7 @@ func Run() error {
 
 		recipe, err := config.LoadRecipe(cfg.RecipeDir, name)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "skipping %s: %v\n", name, err)
+			p.fail(name, err)
 			continue
 		}
 
@@ -60,7 +60,7 @@ func Run() error {
 		}
 
 		if err := CreateSession(name, recipe); err != nil {
-			fmt.Fprintf(os.Stderr, "error creating %s: %v\n", name, err)
+			p.fail(name, err)
 			continue
 		}
 
@@ -69,6 +69,13 @@ func Run() error {
 	}
 
 	p.halt()
+	p.reportFailures()
+
+	// Fail loud if any active recipe couldn't start. Done before auto-attach so
+	// the failure summary isn't buried behind an attached session.
+	if p.failed_ > 0 {
+		return fmt.Errorf("%d recipe(s) failed to start", p.failed_)
+	}
 
 	// Auto-attach after session creation.
 	if p.done_ == 0 {


### PR DESCRIPTION
Closes #46.

`tspmo` silently did nothing when `recipe-dir` was missing — `ensureTemplate` was a best-effort no-op and recipe-load failures were swallowed.

- `ensureRecipeDir` now creates the dir + `template.toml` and returns real errors (Load propagates them).
- Recipe load / session creation failures mark a `failed` state in the spinner and `tspmo` exits non-zero with a summary.