### PR TITLE
feat(recipe): split windows into panes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,14 +90,40 @@ commands = ["make run"]
 - `start-directory` on a window is relative to the recipe's top-level start-directory
 - `commands` is optional; if omitted the window just opens a shell
 - `~` and environment variables are expanded in paths
-- No pane/split support — one pane per window, keep it simple
+
+**Panes** (optional) — a window can be split into multiple panes instead of
+holding a single shell:
+```toml
+[[windows]]
+  [[windows.panes]]
+  commands = ["nvim"]          # pane 1 = the window's base pane
+
+  [[windows.panes]]
+  split = "right"              # new pane goes to the right of pane 1
+  size  = "30%"
+  commands = ["lazygit"]       # pane 2
+
+  [[windows.panes]]
+  split = "down"               # splits pane 2 (the previous pane)
+  size  = "50%"
+  start-directory = "logs/"
+  commands = ["tail -f app.log"]
+  focus = true                 # focus this pane when the window opens
+```
+- Pane 1 is the window's base pane; later panes split an earlier one
+- `split-from = <N>` (1-based pane number) chooses which pane to split; omitted defaults to the **previous** pane
+- `split` is `"right"` (side-by-side) or `"down"` (stacked); defaults to `"right"`
+- `size` is a percentage like `"30%"`, optional (tmux splits evenly when omitted). **% is relative to the pane being split**, not the whole window — needs tmux ≥3.1
+- `commands` and `start-directory` work per-pane (start-directory relative to the window's)
+- `focus = true` focuses that pane on open (default is pane 1); only one pane per window may set it
+- A window uses **either** window-level `commands` (single pane, the simple form above) **or** `panes`, never both
 
 ### Subcommand behavior
 
 **`twin tspmo`** (no additional args):
 1. Load twin.toml config
 2. Read the `active` list
-3. For each active recipe: parse the TOML, create a tmux session with windows/commands
+3. For each active recipe: parse the TOML, create a tmux session with windows/panes/commands
 4. Skip recipes whose session name already exists (idempotent)
 5. Show real-time spinner progress (braille animation in TTY, plain lines otherwise)
 6. When `ordered-sessions` is true (default), add 1s delay between spawns to preserve order

--- a/README.md
+++ b/README.md
@@ -90,6 +90,35 @@ commands = ["make run"]
 - `commands` is optional; omit it for a plain shell
 - `~` and environment variables are expanded in paths
 
+### Panes
+
+A window can be split into multiple panes instead of holding a single shell:
+
+```toml
+[[windows]]
+  [[windows.panes]]
+  commands = ["nvim"]          # pane 1 — the window's base pane
+
+  [[windows.panes]]
+  split = "right"              # new pane to the right of pane 1
+  size  = "30%"
+  commands = ["lazygit"]
+
+  [[windows.panes]]
+  split = "down"               # splits the previous pane
+  size  = "50%"
+  start-directory = "logs/"
+  commands = ["tail -f app.log"]
+  focus = true                 # focus this pane when the window opens
+```
+
+- pane 1 is the base pane; later panes split an earlier one
+- `split` is `"right"` (side-by-side) or `"down"` (stacked); defaults to `"right"`
+- `split-from = <N>` (1-based) chooses which pane to split; omit it to split the previous pane
+- `size` is a percentage like `"30%"`, optional — it's relative to the pane being split (needs tmux ≥3.1)
+- `commands`, `start-directory`, and `focus = true` (one per window) work per-pane
+- a window uses **either** window-level `commands` or `panes`, never both
+
 ## Subcommands
 
 ### `twin tspmo`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -53,16 +54,74 @@ func (c Config) BorderColor(cmd string) Color {
 	return Color(raw)
 }
 
+// Pane represents a single pane within a window.
+type Pane struct {
+	StartDirectory string   `toml:"start-directory"`
+	Commands       []string `toml:"commands"`
+	SplitFrom      int      `toml:"split-from"` // 1-based pane number; 0 = previous pane
+	Split          string   `toml:"split"`      // "right" | "down"; defaults to "right"
+	Size           string   `toml:"size"`       // e.g. "30%"; optional (even split when empty)
+	Focus          bool     `toml:"focus"`      // focus this pane on open; default is pane 1
+}
+
 // Window represents a single window in a recipe.
 type Window struct {
 	StartDirectory string   `toml:"start-directory"`
 	Commands       []string `toml:"commands"`
+	Panes          []Pane   `toml:"panes"`
 }
 
 // Recipe represents a single recipe TOML file.
 type Recipe struct {
 	StartDirectory string   `toml:"start-directory"`
 	Windows        []Window `toml:"windows"`
+}
+
+// sizeRe matches a pane size like "30%".
+var sizeRe = regexp.MustCompile(`^\d+%$`)
+
+// Validate checks recipe-level invariants that the TOML decoder can't catch,
+// returning a friendly error pointing at the offending window/pane.
+func (r Recipe) Validate() error {
+	for wi, w := range r.Windows {
+		wn := wi + 1 // 1-based for messages
+
+		if len(w.Commands) > 0 && len(w.Panes) > 0 {
+			return fmt.Errorf("window %d: use either commands or panes, not both", wn)
+		}
+
+		focused := 0
+		for pi, p := range w.Panes {
+			pn := pi + 1
+
+			if pi == 0 {
+				// Pane 1 is the window's base pane; it isn't split off anything.
+				if p.Split != "" || p.SplitFrom != 0 || p.Size != "" {
+					return fmt.Errorf("window %d pane 1: the first pane is the base pane and can't set split/split-from/size", wn)
+				}
+			} else {
+				if p.SplitFrom < 0 || p.SplitFrom > pi {
+					return fmt.Errorf("window %d pane %d: split-from %d references a pane that doesn't exist yet", wn, pn, p.SplitFrom)
+				}
+				switch p.Split {
+				case "", "right", "down":
+				default:
+					return fmt.Errorf("window %d pane %d: split must be \"right\" or \"down\", got %q", wn, pn, p.Split)
+				}
+				if p.Size != "" && !sizeRe.MatchString(p.Size) {
+					return fmt.Errorf("window %d pane %d: size must look like \"30%%\", got %q", wn, pn, p.Size)
+				}
+			}
+
+			if p.Focus {
+				focused++
+			}
+		}
+		if focused > 1 {
+			return fmt.Errorf("window %d: only one pane may set focus = true", wn)
+		}
+	}
+	return nil
 }
 
 // Load reads twin.toml from the config directory.
@@ -102,6 +161,16 @@ func TemplatePath(recipeDir string) string {
 const templateContent = `start-directory = "~/"
 
 [[windows]]
+# commands = ["nvim"]
+
+# split a window into panes instead of using window-level commands:
+# [[windows]]
+#   [[windows.panes]]
+#   commands = ["nvim"]
+#   [[windows.panes]]
+#   split = "right"   # or "down"; defaults to right
+#   size  = "30%"     # optional, relative to the split pane
+#   commands = ["lazygit"]
 `
 
 // ensureRecipeDir guarantees recipeDir exists and contains a template.toml,
@@ -140,6 +209,9 @@ func LoadRecipe(recipeDir, name string) (Recipe, error) {
 	}
 
 	r.StartDirectory = expandPath(r.StartDirectory)
+	if err := r.Validate(); err != nil {
+		return r, fmt.Errorf("invalid recipe %s: %w", path, err)
+	}
 	return r, nil
 }
 
@@ -194,7 +266,13 @@ func scaffold(dir string) error {
 	homeRecipe := `start-directory = "~/"
 
 [[windows]]
-commands = ["ls -lAh"]
+  [[windows.panes]]
+  commands = ["ls -lAh"]
+
+  [[windows.panes]]
+  split = "right"
+  size = "35%"
+  commands = ["echo \"twin supports panes — see template.toml\""]
 
 [[windows]]
 start-directory = ".config/"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,105 @@
+package config
+
+import "testing"
+
+func TestRecipeValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		recipe  Recipe
+		wantErr bool
+	}{
+		{
+			name:   "empty recipe",
+			recipe: Recipe{},
+		},
+		{
+			name: "window with commands only",
+			recipe: Recipe{Windows: []Window{
+				{Commands: []string{"nvim"}},
+			}},
+		},
+		{
+			name: "valid pane tree",
+			recipe: Recipe{Windows: []Window{
+				{Panes: []Pane{
+					{Commands: []string{"nvim"}},
+					{Split: "right", Size: "30%", Commands: []string{"lazygit"}},
+					{Split: "down", Size: "50%", Focus: true},
+				}},
+			}},
+		},
+		{
+			name: "split-from referencing earlier pane",
+			recipe: Recipe{Windows: []Window{
+				{Panes: []Pane{
+					{Commands: []string{"nvim"}},
+					{Split: "right"},
+					{SplitFrom: 1, Split: "down"},
+				}},
+			}},
+		},
+		{
+			name: "commands and panes both set",
+			recipe: Recipe{Windows: []Window{
+				{Commands: []string{"nvim"}, Panes: []Pane{{Commands: []string{"ls"}}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "base pane sets split",
+			recipe: Recipe{Windows: []Window{
+				{Panes: []Pane{{Split: "right"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "split-from out of range",
+			recipe: Recipe{Windows: []Window{
+				{Panes: []Pane{
+					{Commands: []string{"nvim"}},
+					{SplitFrom: 5},
+				}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "invalid split direction",
+			recipe: Recipe{Windows: []Window{
+				{Panes: []Pane{
+					{Commands: []string{"nvim"}},
+					{Split: "sideways"},
+				}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "invalid size",
+			recipe: Recipe{Windows: []Window{
+				{Panes: []Pane{
+					{Commands: []string{"nvim"}},
+					{Split: "right", Size: "30"},
+				}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "two focused panes",
+			recipe: Recipe{Windows: []Window{
+				{Panes: []Pane{
+					{Commands: []string{"nvim"}, Focus: true},
+					{Split: "right", Focus: true},
+				}},
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.recipe.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
+	"unsafe"
 )
 
 // HasSession returns true if a tmux session with the given name exists.
@@ -16,18 +18,65 @@ func HasSession(name string) bool {
 	return err == nil
 }
 
-// NewSession creates a new detached tmux session.
-func NewSession(name, startDir string) error {
-	return exec.Command("tmux", "new-session", "-d", "-s", name, "-c", startDir).Run()
+// NewSession creates a new detached tmux session and returns the pane-id
+// (e.g. "%3") of its first window's base pane.
+//
+// The session is sized to the destination terminal via -x/-y. Without this a
+// detached session falls back to tmux's 80x24 default-size, so pane split
+// percentages are computed against that tiny grid; when the session is later
+// attached to a larger terminal tmux spreads the extra space across panes,
+// dragging every non-50% split toward 50%. Creating at the final size keeps
+// the percentages honest. Falls back to tmux's default when the size is
+// unknown (e.g. stdout isn't a terminal).
+func NewSession(name, startDir string) (string, error) {
+	args := []string{"new-session", "-d", "-s", name, "-c", startDir}
+	if cols, rows := SessionSize(); cols > 0 && rows > 0 {
+		args = append(args, "-x", strconv.Itoa(cols), "-y", strconv.Itoa(rows))
+	}
+	args = append(args, "-P", "-F", "#{pane_id}")
+	return paneIDOf(exec.Command("tmux", args...))
 }
 
-// NewWindow creates a new window in an existing session.
-// target is "session:index" (e.g. "front:2").
-func NewWindow(target, startDir string) error {
-	return exec.Command("tmux", "new-window", "-t", target, "-c", startDir).Run()
+// NewWindow creates a new window in an existing session and returns the pane-id
+// of its base pane. target is "session:index" (e.g. "front:2").
+func NewWindow(target, startDir string) (string, error) {
+	return paneIDOf(exec.Command("tmux", "new-window", "-t", target,
+		"-c", startDir, "-P", "-F", "#{pane_id}"))
 }
 
-// SendKeys sends keystrokes to a tmux target (e.g. "front:1").
+// SplitPane splits the pane identified by targetPaneID and returns the new
+// pane's pane-id. direction is "down" for a stacked split (-v) or anything else
+// for a side-by-side split (-h). size, when non-empty, is a tmux size such as
+// "30%" (requires tmux >= 3.1); empty means an even split.
+func SplitPane(targetPaneID, startDir, direction, size string) (string, error) {
+	args := []string{"split-window", "-t", targetPaneID, "-c", startDir}
+	if direction == "down" {
+		args = append(args, "-v")
+	} else {
+		args = append(args, "-h")
+	}
+	if size != "" {
+		args = append(args, "-l", size)
+	}
+	args = append(args, "-P", "-F", "#{pane_id}")
+	return paneIDOf(exec.Command("tmux", args...))
+}
+
+// SelectPane focuses the pane identified by paneID (e.g. "%3").
+func SelectPane(paneID string) error {
+	return exec.Command("tmux", "select-pane", "-t", paneID).Run()
+}
+
+// paneIDOf runs a tmux command that prints a pane-id and returns it trimmed.
+func paneIDOf(cmd *exec.Cmd) (string, error) {
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// SendKeys sends keystrokes to a tmux target (e.g. "front:1" or a pane-id "%3").
 func SendKeys(target, keys string) error {
 	return exec.Command("tmux", "send-keys", "-t", target, keys, "C-m").Run()
 }
@@ -204,6 +253,38 @@ func ClientSize() (width, height int, err error) {
 	w, _ := strconv.Atoi(fields[0])
 	h, _ := strconv.Atoi(fields[1])
 	return w, h, nil
+}
+
+// SessionSize returns the columns and rows a new detached session should be
+// created at so that pane split percentages match the terminal it ends up on.
+// Inside tmux it uses the current client (we'll switch-client into the new
+// session); outside tmux it measures stdout directly (we'll attach into it).
+// Returns (0, 0) when the size can't be determined, leaving tmux's default.
+func SessionSize() (cols, rows int) {
+	if InTmux() {
+		if w, h, err := ClientSize(); err == nil && w > 0 && h > 0 {
+			return w, h
+		}
+	}
+	return terminalSize()
+}
+
+// terminalSize asks the kernel for the size of the terminal on stdout via the
+// TIOCGWINSZ ioctl. Returns (0, 0) when stdout isn't a terminal (e.g. a pipe).
+func terminalSize() (cols, rows int) {
+	var ws struct {
+		Row, Col, Xpixel, Ypixel uint16
+	}
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		os.Stdout.Fd(),
+		uintptr(syscall.TIOCGWINSZ),
+		uintptr(unsafe.Pointer(&ws)),
+	)
+	if errno != 0 {
+		return 0, 0
+	}
+	return int(ws.Col), int(ws.Row)
 }
 
 // KillSession kills a single tmux session by name.

--- a/internal/tspmo/tspmo.go
+++ b/internal/tspmo/tspmo.go
@@ -123,52 +123,106 @@ func attachTarget(cfg config.Config) (string, error) {
 	return "", nil
 }
 
-// CreateSession builds a tmux session from a recipe: creates windows and sends commands.
+// CreateSession builds a tmux session from a recipe: creates windows, splits
+// panes, and sends commands.
 func CreateSession(name string, recipe config.Recipe) error {
-	// The first window is created with the session itself (window index 1,
-	// since tmux base-index is commonly 1, but we use the default here).
 	baseDir := recipe.StartDirectory
 
-	firstWindowDir := baseDir
-	if len(recipe.Windows) > 0 && recipe.Windows[0].StartDirectory != "" {
-		firstWindowDir = filepath.Join(baseDir, recipe.Windows[0].StartDirectory)
-	}
-
-	if err := tmux.NewSession(name, firstWindowDir); err != nil {
-		return fmt.Errorf("new-session: %w", err)
-	}
-
-	// Send commands to the first window.
-	if len(recipe.Windows) > 0 {
-		for _, cmd := range recipe.Windows[0].Commands {
-			if err := tmux.SendKeys(name+":1", cmd); err != nil {
-				return fmt.Errorf("send-keys to %s:1: %w", name, err)
-			}
-		}
-	}
-
-	// Create remaining windows (index 2, 3, ...).
-	for i := 1; i < len(recipe.Windows); i++ {
-		w := recipe.Windows[i]
-		winDir := baseDir
+	for i, w := range recipe.Windows {
+		// windowDir is where the window's base pane opens; a per-pane
+		// start-directory on pane 1 narrows it further (matching window dirs).
+		windowDir := baseDir
 		if w.StartDirectory != "" {
-			winDir = filepath.Join(baseDir, w.StartDirectory)
+			windowDir = filepath.Join(baseDir, w.StartDirectory)
+		}
+		basePaneDir := windowDir
+		if len(w.Panes) > 0 && w.Panes[0].StartDirectory != "" {
+			basePaneDir = filepath.Join(windowDir, w.Panes[0].StartDirectory)
 		}
 
-		target := fmt.Sprintf("%s:%d", name, i+1)
-		if err := tmux.NewWindow(target, winDir); err != nil {
-			return fmt.Errorf("new-window %s: %w", target, err)
-		}
-
-		for _, cmd := range w.Commands {
-			if err := tmux.SendKeys(target, cmd); err != nil {
-				return fmt.Errorf("send-keys to %s: %w", target, err)
+		// The first window is created with the session itself; the rest are
+		// new windows. Both hand back the base pane's stable pane-id.
+		var basePaneID string
+		var err error
+		if i == 0 {
+			if basePaneID, err = tmux.NewSession(name, basePaneDir); err != nil {
+				return fmt.Errorf("new-session: %w", err)
 			}
+		} else {
+			target := fmt.Sprintf("%s:%d", name, i+1)
+			if basePaneID, err = tmux.NewWindow(target, basePaneDir); err != nil {
+				return fmt.Errorf("new-window %s: %w", target, err)
+			}
+		}
+
+		if err := buildWindow(basePaneID, w, windowDir); err != nil {
+			return fmt.Errorf("window %d: %w", i+1, err)
 		}
 	}
 
 	// Select the first window so the session starts there.
 	tmux.SelectWindow(name + ":1")
 
+	return nil
+}
+
+// buildWindow populates an already-created window. With no panes it sends the
+// window-level commands to the base pane (the original single-pane behavior).
+// With panes it splits the tree, sends per-pane commands, and focuses one pane.
+func buildWindow(basePaneID string, w config.Window, windowDir string) error {
+	if len(w.Panes) == 0 {
+		return sendCommands(basePaneID, w.Commands)
+	}
+
+	paneIDs := make([]string, len(w.Panes))
+	paneIDs[0] = basePaneID
+	if err := sendCommands(basePaneID, w.Panes[0].Commands); err != nil {
+		return err
+	}
+
+	for i := 1; i < len(w.Panes); i++ {
+		p := w.Panes[i]
+
+		// split-from is 1-based; 0 means the previous pane.
+		targetIdx := i - 1
+		if p.SplitFrom > 0 {
+			targetIdx = p.SplitFrom - 1
+		}
+
+		paneDir := windowDir
+		if p.StartDirectory != "" {
+			paneDir = filepath.Join(windowDir, p.StartDirectory)
+		}
+
+		id, err := tmux.SplitPane(paneIDs[targetIdx], paneDir, p.Split, p.Size)
+		if err != nil {
+			return fmt.Errorf("split pane %d: %w", i+1, err)
+		}
+		paneIDs[i] = id
+
+		if err := sendCommands(id, p.Commands); err != nil {
+			return err
+		}
+	}
+
+	// Focus the requested pane, defaulting to the base pane.
+	focus := paneIDs[0]
+	for i, p := range w.Panes {
+		if p.Focus {
+			focus = paneIDs[i]
+		}
+	}
+	tmux.SelectPane(focus)
+
+	return nil
+}
+
+// sendCommands dispatches each command to a tmux target (pane-id or window).
+func sendCommands(target string, commands []string) error {
+	for _, cmd := range commands {
+		if err := tmux.SendKeys(target, cmd); err != nil {
+			return fmt.Errorf("send-keys to %s: %w", target, err)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Closes #47.

Windows can now declare an ordered `panes` array. Pane 1 is the base pane; later panes split an earlier one via `split-from` (1-based, defaults to previous), with `split` (right/down), optional `size` %, per-pane `commands`/`start-directory`, and opt-in `focus`. Window-level `commands` and `panes` are mutually exclusive — window-only recipes are unchanged.

`Recipe.Validate` rejects bad configs with friendly messages (both commands+panes, base pane splitting, out-of-range split-from, bad split/size, multiple focus). Covered by `config_test.go`.

New sessions are sized to the destination terminal (`-x/-y`) so split percentages land correctly. Without it a detached session defaults to 80x24 and attaching to a larger terminal drags every non-50% split toward 50%; size comes from the tmux client in-tmux, else a `TIOCGWINSZ` ioctl on stdout. Verified both paths produce exact geometry.

Docs (CLAUDE.md, README.md) updated with the pane config and rules.