### PR TITLE
chore(ci): bump actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,18 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
       # nix-hash must be on PATH for goreleaser's nix pipe to compute SRI hashes
       - uses: cachix/install-nix-action@v31
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: '~> v2'


### PR DESCRIPTION
Closes #50.

GitHub is forcing Node 20 actions onto Node 24 (flagged on the v0.2.0 release run). Bump to current majors:

- `actions/checkout` v4 → v6
- `actions/setup-go` v5 → v6
- `goreleaser/goreleaser-action` v6 → v7

Only touches `release.yml`; exercised on the next tag push.