### PR TITLE
feat(shkspr): open a recipe by name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,11 @@ holding a single shell:
 Not meant to be called directly. Uses `os.Executable()` for the absolute path since the
 popup shell doesn't inherit PATH context.
 
+**`twin shkspr`** — open config in `$EDITOR` (falls back to vim, then nano):
+- `twin shkspr` — open `twin.toml`
+- `twin shkspr <recipe>` — open `<recipe-dir>/<recipe>.toml` (a trailing `.toml` is trimmed, so `dots` and `dots.toml` are equivalent)
+- Opening a recipe name that doesn't exist yet drops you into the editor on a fresh file — a quick way to start a new recipe
+
 **Teardown**: not a twin concern — just use `tmux kill-server` or kill individual sessions manually.
 
 ## Development workflow

--- a/cmd/twin/main.go
+++ b/cmd/twin/main.go
@@ -109,7 +109,7 @@ commands:
   sybau    fzf-based session switcher
   pbqt     kill a tmux session (fzf picker / name)
   icl      quick-glance at running Claude agent panes
-  shkspr   open twin.toml in $EDITOR
+  shkspr   open twin.toml in $EDITOR (or a recipe by name)
   tysm     kill tmux server with a farewell
 
 run 'twin <command> --help' for command-specific help.

--- a/internal/shkspr/shkspr.go
+++ b/internal/shkspr/shkspr.go
@@ -1,28 +1,26 @@
 package shkspr
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/Josef-Hlink/twin/internal/config"
 )
 
-const Usage = `usage: twin shkspr [--recipes | -r]
+const Usage = `usage: twin shkspr [recipe]
 
 open twin.toml in $EDITOR (or vim/nano if unset).
-  --recipes, -r open the recipes directory instead of twin.toml
+  recipe  open that recipe file instead (e.g. "twin shkspr dots" -> dots.toml)
 `
 
-// Run opens the twin.toml config file or the recipes directory in the
-// user's editor.
+// Run opens the twin.toml config file, or a single recipe file when a recipe
+// name is given, in the user's editor.
 func Run(args []string) error {
-	fs := flag.NewFlagSet("shkspr", flag.ContinueOnError)
-	recipes := fs.Bool("recipes", false, "open the recipes directory")
-	fs.BoolVar(recipes, "r", false, "open the recipes directory (shorthand)")
-	if err := fs.Parse(args); err != nil {
-		return err
+	if len(args) > 1 {
+		return fmt.Errorf("expected at most one recipe name, got %d", len(args))
 	}
 
 	editor, err := resolveEditor()
@@ -31,12 +29,13 @@ func Run(args []string) error {
 	}
 
 	var path string
-	if *recipes {
+	if len(args) == 1 {
 		cfg, err := config.Load()
 		if err != nil {
 			return err
 		}
-		path = cfg.RecipeDir
+		name := strings.TrimSuffix(args[0], ".toml")
+		path = filepath.Join(cfg.RecipeDir, name+".toml")
 	} else {
 		path = config.ConfigPath()
 	}


### PR DESCRIPTION
`twin shkspr <recipe>` opens `<recipe-dir>/<recipe>.toml`; no arg still opens twin.toml. Replaces the awkward `-r` flag.

Closes #52