### PR TITLE
build(nix): add devShell + gofmt/go vet pre-commit hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,10 @@ popup shell doesn't inherit PATH context.
 
 ### Building
 
+The Go toolchain comes from a per-project nix devShell (`flake.nix`), not a global
+install. direnv auto-loads it on `cd` into the repo; if direnv is off, run `nix develop`
+to enter the shell manually.
+
 ```sh
 go build ./cmd/twin    # produces ./twin binary
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "twin — dev environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "aarch64-darwin" "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (s: f nixpkgs.legacyPackages.${s});
+    in {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.go_1_25   # matches `go 1.25.4` in go.mod (unstable default `go` is 1.26)
+            pkgs.gopls     # editor LSP
+            pkgs.gotools   # goimports & friends
+          ];
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,14 +8,42 @@
       systems = [ "aarch64-darwin" "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (s: f nixpkgs.legacyPackages.${s});
     in {
-      devShells = forAllSystems (pkgs: {
-        default = pkgs.mkShell {
-          packages = [
-            pkgs.go_1_25   # matches `go 1.25.4` in go.mod (unstable default `go` is 1.26)
-            pkgs.gopls     # editor LSP
-            pkgs.gotools   # goimports & friends
-          ];
-        };
-      });
+      devShells = forAllSystems (pkgs:
+        let
+          go = pkgs.go_1_25;   # matches `go 1.25.4` in go.mod (unstable default `go` is 1.26)
+
+          # gofmt + go vet gate, run against staged Go files before each commit.
+          # Uses absolute store paths so it works even when invoked outside the shell.
+          preCommit = pkgs.writeShellScript "twin-pre-commit" ''
+            set -euo pipefail
+            files=$(git diff --cached --name-only --diff-filter=ACM -- '*.go')
+            if [ -n "$files" ]; then
+              unformatted=$(${go}/bin/gofmt -l $files)
+              if [ -n "$unformatted" ]; then
+                echo "gofmt: staged Go files need formatting:" >&2
+                echo "$unformatted" >&2
+                echo "fix with: gofmt -w $unformatted" >&2
+                exit 1
+              fi
+            fi
+            ${go}/bin/go vet ./...
+          '';
+        in {
+          default = pkgs.mkShell {
+            packages = [
+              go
+              pkgs.gopls     # editor LSP
+              pkgs.gotools   # goimports & friends
+            ];
+
+            # Symlink the pre-commit hook in on shell entry; refreshed each time
+            # so it tracks the pinned toolchain. Skipped outside a git checkout.
+            shellHook = ''
+              if [ -d .git ]; then
+                ln -sf ${preCommit} .git/hooks/pre-commit
+              fi
+            '';
+          };
+        });
     };
 }


### PR DESCRIPTION
Adds a per-project nix devShell so the Go toolchain no longer depends on a global install — direnv auto-loads it on `cd`; `nix develop` otherwise. Pins `go_1_25` (matches `go.mod`) plus `gopls` and `gotools`; `flake.lock` is nixpkgs-only.

Also installs a gofmt + `go vet` pre-commit hook via the devShell `shellHook` (built with `writeShellScript`, toolchain store paths baked in — works outside the shell too). No new flake inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
