### PR TITLE
feat(popup): cap picker height with max-options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,10 @@ active = ["front", "back", "infra"]
 # also enables session numbering in sybau picker. defaults to true.
 ordered-sessions = true
 
+# optional: cap how many rows the popup pickers (fr/sybau/pbqt) are sized for.
+# fzf scrolls through any options beyond the cap. omitted/0 = grow to fit all.
+max-options = 10
+
 # optional: auto-attach to this session after tspmo finishes (must be in active list).
 # if omitted, tspmo prompts the user.
 auto-attach-to = "front"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ icl-border-color   = "colour214"  # default: colour214 (orange)
 
 Values accept any form both tools take: a named color (`red`, `magenta`, `cyan`, …), a 256-color index (`214` or `colour214`), or hex (`#ff8800`).
 
+### Popup size
+
+By default the list pickers (`fr`, `sybau`, `pbqt`) grow their popup to fit every option, which gets tall and thin with a long list. `max-options` caps how many rows the popup is sized for; fzf scrolls through the rest and shows its `matched/total` count so you can tell more options exist.
+
+```toml
+max-options = 10   # omit (or 0) to grow the popup to fit every option
+```
+
+The cap applies only to the tmux popup. Outside tmux the pickers fall back to inline fzf, which manages its own height.
+
 ## Recipes
 
 Each recipe is a TOML file in the recipe directory. The filename becomes the session name.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	RecipeDir        string   `toml:"recipe-dir"`
 	Active           []string `toml:"active"`
 	OrderedSessions  *bool    `toml:"ordered-sessions"`
+	MaxOptions       *int     `toml:"max-options"`
 	AutoAttachTo     string   `toml:"auto-attach-to"`
 	TysmMsg          string   `toml:"tysm-msg"`
 	FrBorderColor    string   `toml:"fr-border-color"`
@@ -30,6 +31,16 @@ func (c Config) IsOrderedSessions() bool {
 		return true
 	}
 	return *c.OrderedSessions
+}
+
+// OptionCap returns the maximum number of list rows a popup picker is sized
+// for; fzf scrolls through any options beyond it. Returns 0 (no cap — the popup
+// grows to fit every option) when unset or non-positive.
+func (c Config) OptionCap() int {
+	if c.MaxOptions == nil || *c.MaxOptions < 1 {
+		return 0
+	}
+	return *c.MaxOptions
 }
 
 // BorderColor returns the popup border + fzf accent color for the given

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,27 @@ package config
 
 import "testing"
 
+func TestOptionCap(t *testing.T) {
+	ptr := func(n int) *int { return &n }
+	tests := []struct {
+		name string
+		cfg  Config
+		want int
+	}{
+		{"unset", Config{}, 0},
+		{"zero", Config{MaxOptions: ptr(0)}, 0},
+		{"negative", Config{MaxOptions: ptr(-3)}, 0},
+		{"positive", Config{MaxOptions: ptr(8)}, 8},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.OptionCap(); got != tt.want {
+				t.Fatalf("OptionCap() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRecipeValidate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/fr/fr.go
+++ b/internal/fr/fr.go
@@ -130,13 +130,13 @@ func pick() error {
 
 	color := cfg.BorderColor("fr")
 	if tmux.InTmux() {
-		return pickPopup(available, color)
+		return pickPopup(available, color, cfg.OptionCap())
 	}
 	return pickInline(available, color)
 }
 
 // pickPopup launches a tmux popup with the fr-picker subcommand.
-func pickPopup(available []string, color config.Color) error {
+func pickPopup(available []string, color config.Color, optionCap int) error {
 	maxLine := len("fr") // minimum width
 	for _, name := range available {
 		if len(name) > maxLine {
@@ -144,7 +144,7 @@ func pickPopup(available []string, color config.Color) error {
 		}
 	}
 
-	width, height := popup.Dims(len(available), maxLine, 0, 0, false)
+	width, height := popup.Dims(len(available), maxLine, optionCap, 0, 0, false)
 	return popup.Launch("fr", width, height, "fr-picker", color)
 }
 

--- a/internal/pbqt/pbqt.go
+++ b/internal/pbqt/pbqt.go
@@ -80,13 +80,13 @@ func pick() error {
 	color := cfg.BorderColor("pbqt")
 	numbered := cfg.IsOrderedSessions()
 	if tmux.InTmux() {
-		return pickPopup(sessions, color, numbered)
+		return pickPopup(sessions, color, numbered, cfg.OptionCap())
 	}
 	return pickInline(sessions, color, numbered)
 }
 
 // pickPopup launches a tmux popup with the pbqt-picker subcommand.
-func pickPopup(sessions []string, color config.Color, numbered bool) error {
+func pickPopup(sessions []string, color config.Color, numbered bool, optionCap int) error {
 	current, _ := tmux.CurrentSession()
 	lines := buildLines(sessions, current, numbered)
 
@@ -97,7 +97,7 @@ func pickPopup(sessions []string, color config.Color, numbered bool) error {
 		}
 	}
 
-	width, height := popup.Dims(len(lines), maxLine, 0, 0, false)
+	width, height := popup.Dims(len(lines), maxLine, optionCap, 0, 0, false)
 	return popup.Launch("pbqt", width, height, "pbqt-picker", color)
 }
 
@@ -178,4 +178,3 @@ func stripDecorations(selected string, numbered bool) string {
 	selected = strings.TrimSuffix(selected, " *")
 	return selected
 }
-

--- a/internal/popup/popup.go
+++ b/internal/popup/popup.go
@@ -18,8 +18,12 @@ const (
 
 // Dims computes popup width and height from content metrics.
 // When preview is false, the preview columns are ignored and the popup
-// is sized for the list alone.
-func Dims(itemCount, maxItemLine, maxPreviewLine, maxPreviewCount int, preview bool) (width, height int) {
+// is sized for the list alone. maxItems, when > 0, caps the number of list
+// rows the popup is sized for; fzf scrolls through any items beyond it.
+func Dims(itemCount, maxItemLine, maxItems, maxPreviewLine, maxPreviewCount int, preview bool) (width, height int) {
+	if maxItems > 0 && itemCount > maxItems {
+		itemCount = maxItems
+	}
 	width = maxItemLine + chromeWidth
 	height = itemCount + chromeHeight
 	if preview {

--- a/internal/sybau/sybau.go
+++ b/internal/sybau/sybau.go
@@ -60,7 +60,7 @@ func Run(args []string) error {
 		maxPreviewLine, maxWindowCount = windowMetrics(sessions, current)
 	}
 
-	width, height := popup.Dims(count, maxListLine, maxPreviewLine, maxWindowCount, preview)
+	width, height := popup.Dims(count, maxListLine, cfg.OptionCap(), maxPreviewLine, maxWindowCount, preview)
 
 	cmd := "sybau-picker"
 	if preview {
@@ -155,4 +155,3 @@ func windowMetrics(sessions []string, skip string) (maxLine, maxCount int) {
 	}
 	return maxLine, maxCount
 }
-


### PR DESCRIPTION
Closes #55.

The list pickers (`fr`, `sybau`, `pbqt`) sized their tmux popup to fit every option, so a long list produced a tall, thin popup that could run past the screen.

Adds a global `max-options` config key that caps how many rows the popup is sized for. `popup.Dims` clamps the item count; fzf scrolls the rest and surfaces its `matched/total` count as the "more options" indicator. Unset / `0` / negative = no cap (current behavior).

`icl` is excluded — it's a tab viewer, not a scrollable list. The inline-fzf fallback (outside tmux) is unaffected since fzf manages its own height there.

Includes a `TestOptionCap` unit test and config docs in README + CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)