### PR TITLE
feat(recipe): singular `command` string for windows/panes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,23 +76,24 @@ start-directory = "~/Developer/pro/my-frontend/"
 
 [[windows]]
 start-directory = "src/"    # relative to recipe start-directory
-commands = ["nvim"]
+command = "nvim"
 
 [[windows]]
 # empty window, just a shell
 
 [[windows]]
-commands = ["lazygit"]
+command = "lazygit"
 
 [[windows]]
-commands = ["make run"]
+commands = ["npm install", "make run"]  # list = each entry on its own shell line
 ```
 
 - Session name = recipe filename (front.toml -> session "front")
 - `start-directory` at the top level is required
 - `windows` is an ordered array; window names are optional (tmux shows the active command by default)
 - `start-directory` on a window is relative to the recipe's top-level start-directory
-- `commands` is optional; if omitted the window just opens a shell
+- `command = "x"` runs a single command; if omitted the window just opens a shell
+- `commands = ["x", "y"]` runs each entry as its own shell line (a short setup sequence). A window uses `command` **or** `commands`, never both
 - `~` and environment variables are expanded in paths
 
 **Panes** (optional) — a window can be split into multiple panes instead of
@@ -100,27 +101,27 @@ holding a single shell:
 ```toml
 [[windows]]
   [[windows.panes]]
-  commands = ["nvim"]          # pane 1 = the window's base pane
+  command = "nvim"             # pane 1 = the window's base pane
 
   [[windows.panes]]
   split = "right"              # new pane goes to the right of pane 1
   size  = "30%"
-  commands = ["lazygit"]       # pane 2
+  command = "lazygit"          # pane 2
 
   [[windows.panes]]
   split = "down"               # splits pane 2 (the previous pane)
   size  = "50%"
   start-directory = "logs/"
-  commands = ["tail -f app.log"]
+  command = "tail -f app.log"
   focus = true                 # focus this pane when the window opens
 ```
 - Pane 1 is the window's base pane; later panes split an earlier one
 - `split-from = <N>` (1-based pane number) chooses which pane to split; omitted defaults to the **previous** pane
 - `split` is `"right"` (side-by-side) or `"down"` (stacked); defaults to `"right"`
 - `size` is a percentage like `"30%"`, optional (tmux splits evenly when omitted). **% is relative to the pane being split**, not the whole window — needs tmux ≥3.1
-- `commands` and `start-directory` work per-pane (start-directory relative to the window's)
+- `command`/`commands` and `start-directory` work per-pane (start-directory relative to the window's)
 - `focus = true` focuses that pane on open (default is pane 1); only one pane per window may set it
-- A window uses **either** window-level `commands` (single pane, the simple form above) **or** `panes`, never both
+- A window uses **either** window-level `command`/`commands` (single pane, the simple form above) **or** `panes`, never both
 
 ### Subcommand behavior
 

--- a/README.md
+++ b/README.md
@@ -83,21 +83,24 @@ start-directory = "~/Developer/pro/my-frontend/"
 
 [[windows]]
 start-directory = "src/"
-commands = ["nvim"]
+command = "nvim"
 
 [[windows]]
 # empty window — just a shell
 
 [[windows]]
-commands = ["lazygit"]
+command = "lazygit"
 
 [[windows]]
-commands = ["make run"]
+# commands = [...] runs each entry as a separate shell line
+commands = ["npm install", "make run"]
 ```
 
 - `start-directory` (top-level) is required
 - `start-directory` on a window is relative to the recipe's top-level directory
-- `commands` is optional; omit it for a plain shell
+- `command = "x"` runs a single command; omit it for a plain shell
+- `commands = ["x", "y"]` runs each entry as its own shell line — handy for a short
+  setup sequence (or just chain with `&&`). Use `command` **or** `commands`, not both
 - `~` and environment variables are expanded in paths
 
 ### Panes
@@ -107,18 +110,18 @@ A window can be split into multiple panes instead of holding a single shell:
 ```toml
 [[windows]]
   [[windows.panes]]
-  commands = ["nvim"]          # pane 1 — the window's base pane
+  command = "nvim"             # pane 1 — the window's base pane
 
   [[windows.panes]]
   split = "right"              # new pane to the right of pane 1
   size  = "30%"
-  commands = ["lazygit"]
+  command = "lazygit"
 
   [[windows.panes]]
   split = "down"               # splits the previous pane
   size  = "50%"
   start-directory = "logs/"
-  commands = ["tail -f app.log"]
+  command = "tail -f app.log"
   focus = true                 # focus this pane when the window opens
 ```
 
@@ -126,8 +129,8 @@ A window can be split into multiple panes instead of holding a single shell:
 - `split` is `"right"` (side-by-side) or `"down"` (stacked); defaults to `"right"`
 - `split-from = <N>` (1-based) chooses which pane to split; omit it to split the previous pane
 - `size` is a percentage like `"30%"`, optional — it's relative to the pane being split (needs tmux ≥3.1)
-- `commands`, `start-directory`, and `focus = true` (one per window) work per-pane
-- a window uses **either** window-level `commands` or `panes`, never both
+- `command`/`commands`, `start-directory`, and `focus = true` (one per window) work per-pane
+- a window uses **either** `command`/`commands` or `panes`, never both
 
 ## Subcommands
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,7 +68,8 @@ func (c Config) BorderColor(cmd string) Color {
 // Pane represents a single pane within a window.
 type Pane struct {
 	StartDirectory string   `toml:"start-directory"`
-	Commands       []string `toml:"commands"`
+	Command        string   `toml:"command"`    // single command; mutually exclusive with commands
+	Commands       []string `toml:"commands"`   // command list; mutually exclusive with command
 	SplitFrom      int      `toml:"split-from"` // 1-based pane number; 0 = previous pane
 	Split          string   `toml:"split"`      // "right" | "down"; defaults to "right"
 	Size           string   `toml:"size"`       // e.g. "30%"; optional (even split when empty)
@@ -78,9 +79,25 @@ type Pane struct {
 // Window represents a single window in a recipe.
 type Window struct {
 	StartDirectory string   `toml:"start-directory"`
-	Commands       []string `toml:"commands"`
+	Command        string   `toml:"command"`  // single command; mutually exclusive with commands
+	Commands       []string `toml:"commands"` // command list; mutually exclusive with command
 	Panes          []Pane   `toml:"panes"`
 }
+
+// chooseCommands returns the effective command list, preferring the singular
+// command over the commands list. Validate guarantees they're never both set.
+func chooseCommands(command string, commands []string) []string {
+	if command != "" {
+		return []string{command}
+	}
+	return commands
+}
+
+// Cmds returns the window's effective commands (singular command or the list).
+func (w Window) Cmds() []string { return chooseCommands(w.Command, w.Commands) }
+
+// Cmds returns the pane's effective commands (singular command or the list).
+func (p Pane) Cmds() []string { return chooseCommands(p.Command, p.Commands) }
 
 // Recipe represents a single recipe TOML file.
 type Recipe struct {
@@ -97,13 +114,20 @@ func (r Recipe) Validate() error {
 	for wi, w := range r.Windows {
 		wn := wi + 1 // 1-based for messages
 
-		if len(w.Commands) > 0 && len(w.Panes) > 0 {
-			return fmt.Errorf("window %d: use either commands or panes, not both", wn)
+		if (w.Command != "" || len(w.Commands) > 0) && len(w.Panes) > 0 {
+			return fmt.Errorf("window %d: use either command(s) or panes, not both", wn)
+		}
+		if w.Command != "" && len(w.Commands) > 0 {
+			return fmt.Errorf("window %d: use either command or commands, not both", wn)
 		}
 
 		focused := 0
 		for pi, p := range w.Panes {
 			pn := pi + 1
+
+			if p.Command != "" && len(p.Commands) > 0 {
+				return fmt.Errorf("window %d pane %d: use either command or commands, not both", wn, pn)
+			}
 
 			if pi == 0 {
 				// Pane 1 is the window's base pane; it isn't split off anything.
@@ -172,16 +196,17 @@ func TemplatePath(recipeDir string) string {
 const templateContent = `start-directory = "~/"
 
 [[windows]]
-# commands = ["nvim"]
+# command = "nvim"                          # a single command
+# commands = ["npm install", "make run"]    # or a list, one shell line each
 
-# split a window into panes instead of using window-level commands:
+# split a window into panes instead of using window-level command(s):
 # [[windows]]
 #   [[windows.panes]]
-#   commands = ["nvim"]
+#   command = "nvim"
 #   [[windows.panes]]
 #   split = "right"   # or "down"; defaults to right
 #   size  = "30%"     # optional, relative to the split pane
-#   commands = ["lazygit"]
+#   command = "lazygit"
 `
 
 // ensureRecipeDir guarantees recipeDir exists and contains a template.toml,
@@ -278,16 +303,16 @@ func scaffold(dir string) error {
 
 [[windows]]
   [[windows.panes]]
-  commands = ["ls -lAh"]
+  command = "ls -lAh"
 
   [[windows.panes]]
   split = "right"
   size = "35%"
-  commands = ["echo \"twin supports panes — see template.toml\""]
+  command = "echo \"twin supports panes — see template.toml\""
 
 [[windows]]
 start-directory = ".config/"
-commands = ["if [ -d nvim ]; then vim nvim/; elif [ -f ~/.vimrc ]; then vim ~/.vimrc; fi"]
+command = "if [ -d nvim ]; then vim nvim/; elif [ -f ~/.vimrc ]; then vim ~/.vimrc; fi"
 
 [[windows]]
 commands = ["cd ` + configDirVar() + `", "echo \"hi twin, here are your recipes:\"", "cat recipes/*.toml"]
@@ -298,7 +323,7 @@ commands = ["cd ` + configDirVar() + `", "echo \"hi twin, here are your recipes:
 [[windows]]
 
 [[windows]]
-commands = ["cd ${GOPATH:-$HOME/go}/bin && ls -la twin"]
+command = "cd ${GOPATH:-$HOME/go}/bin && ls -la twin"
 `, configDirVar())
 
 	files := map[string]string{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,39 @@ func TestRecipeValidate(t *testing.T) {
 			}},
 		},
 		{
+			name: "window with command only",
+			recipe: Recipe{Windows: []Window{
+				{Command: "nvim"},
+			}},
+		},
+		{
+			name: "pane with command only",
+			recipe: Recipe{Windows: []Window{
+				{Panes: []Pane{{Command: "nvim"}}},
+			}},
+		},
+		{
+			name: "window with command and commands",
+			recipe: Recipe{Windows: []Window{
+				{Command: "nvim", Commands: []string{"ls"}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "window with command and panes",
+			recipe: Recipe{Windows: []Window{
+				{Command: "nvim", Panes: []Pane{{Command: "ls"}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "pane with command and commands",
+			recipe: Recipe{Windows: []Window{
+				{Panes: []Pane{{Command: "nvim", Commands: []string{"ls"}}}},
+			}},
+			wantErr: true,
+		},
+		{
 			name: "valid pane tree",
 			recipe: Recipe{Windows: []Window{
 				{Panes: []Pane{
@@ -123,4 +156,41 @@ func TestRecipeValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCmds(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		commands []string
+		want     []string
+	}{
+		{"command only", "nvim", nil, []string{"nvim"}},
+		{"commands only", "", []string{"cd src", "make"}, []string{"cd src", "make"}},
+		{"command wins over commands", "nvim", []string{"ls"}, []string{"nvim"}},
+		{"neither", "", nil, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := Window{Command: tt.command, Commands: tt.commands}
+			p := Pane{Command: tt.command, Commands: tt.commands}
+			for _, got := range [][]string{w.Cmds(), p.Cmds()} {
+				if !equalStrings(got, tt.want) {
+					t.Fatalf("Cmds() = %#v, want %#v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/tspmo/tspmo.go
+++ b/internal/tspmo/tspmo.go
@@ -171,12 +171,12 @@ func CreateSession(name string, recipe config.Recipe) error {
 // With panes it splits the tree, sends per-pane commands, and focuses one pane.
 func buildWindow(basePaneID string, w config.Window, windowDir string) error {
 	if len(w.Panes) == 0 {
-		return sendCommands(basePaneID, w.Commands)
+		return sendCommands(basePaneID, w.Cmds())
 	}
 
 	paneIDs := make([]string, len(w.Panes))
 	paneIDs[0] = basePaneID
-	if err := sendCommands(basePaneID, w.Panes[0].Commands); err != nil {
+	if err := sendCommands(basePaneID, w.Panes[0].Cmds()); err != nil {
 		return err
 	}
 
@@ -200,7 +200,7 @@ func buildWindow(basePaneID string, w config.Window, windowDir string) error {
 		}
 		paneIDs[i] = id
 
-		if err := sendCommands(id, p.Commands); err != nil {
+		if err := sendCommands(id, p.Cmds()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Closes #57.

Recipe windows/panes only accepted `commands = ["x"]` — a list even for the
common single-command case. This adds a singular `command = "x"` alongside the
existing list:

- `command` is now the documented default; `commands` stays for short multi-step setups
- the two are mutually exclusive on a window/pane (as are `command(s)` and `panes`)
- a `Cmds()` helper on `Window`/`Pane` prefers the singular form, so `tspmo`'s send path is unchanged

Additive and non-breaking. Tests cover the new validation rules + helper; docs and the
scaffold show both forms and when each fits.