### PR TITLE
feat(shkspr): `.` opens the current session's recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ popup shell doesn't inherit PATH context.
 **`twin shkspr`** — open config in `$EDITOR` (falls back to vim, then nano):
 - `twin shkspr` — open `twin.toml`
 - `twin shkspr <recipe>` — open `<recipe-dir>/<recipe>.toml` (a trailing `.toml` is trimmed, so `dots` and `dots.toml` are equivalent)
+- `twin shkspr .` — open the recipe named after the currently attached tmux session (errors outside tmux)
 - Opening a recipe name that doesn't exist yet drops you into the editor on a fresh file — a quick way to start a new recipe
 
 **Teardown**: not a twin concern — just use `tmux kill-server` or kill individual sessions manually.

--- a/internal/shkspr/shkspr.go
+++ b/internal/shkspr/shkspr.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 
 	"github.com/Josef-Hlink/twin/internal/config"
+	"github.com/Josef-Hlink/twin/internal/tmux"
 )
 
 const Usage = `usage: twin shkspr [recipe]
 
 open twin.toml in $EDITOR (or vim/nano if unset).
   recipe  open that recipe file instead (e.g. "twin shkspr dots" -> dots.toml)
+          "." means the current tmux session's recipe
 `
 
 // Run opens the twin.toml config file, or a single recipe file when a recipe
@@ -34,7 +36,17 @@ func Run(args []string) error {
 		if err != nil {
 			return err
 		}
-		name := strings.TrimSuffix(args[0], ".toml")
+		name := args[0]
+		if name == "." {
+			if !tmux.InTmux() {
+				return fmt.Errorf(`"." only works inside tmux`)
+			}
+			name, err = tmux.CurrentSession()
+			if err != nil {
+				return fmt.Errorf("could not resolve current session: %w", err)
+			}
+		}
+		name = strings.TrimSuffix(name, ".toml")
 		path = filepath.Join(cfg.RecipeDir, name+".toml")
 	} else {
 		path = config.ConfigPath()


### PR DESCRIPTION
Closes #59. Inside tmux, `twin shkspr .` resolves the attached session name and opens that recipe file; outside tmux it errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)