### PR TITLE
feat(recipe): window names and pane titles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ auto-attach-to = "front"
 start-directory = "~/Developer/pro/my-frontend/"
 
 [[windows]]
+name = "editor"             # optional fixed window name
 start-directory = "src/"    # relative to recipe start-directory
 command = "nvim"
 
@@ -90,7 +91,7 @@ commands = ["npm install", "make run"]  # list = each entry on its own shell lin
 
 - Session name = recipe filename (front.toml -> session "front")
 - `start-directory` at the top level is required
-- `windows` is an ordered array; window names are optional (tmux shows the active command by default)
+- `windows` is an ordered array; `name` is optional — without it tmux shows the active command (an explicit name disables tmux's automatic-rename for that window)
 - `start-directory` on a window is relative to the recipe's top-level start-directory
 - `command = "x"` runs a single command; if omitted the window just opens a shell
 - `commands = ["x", "y"]` runs each entry as its own shell line (a short setup sequence). A window uses `command` **or** `commands`, never both
@@ -101,6 +102,7 @@ holding a single shell:
 ```toml
 [[windows]]
   [[windows.panes]]
+  title = "vim"                # optional pane title, shown in the pane border
   command = "nvim"             # pane 1 = the window's base pane
 
   [[windows.panes]]
@@ -120,6 +122,7 @@ holding a single shell:
 - `split` is `"right"` (side-by-side) or `"down"` (stacked); defaults to `"right"`
 - `size` is a percentage like `"30%"`, optional (tmux splits evenly when omitted). **% is relative to the pane being split**, not the whole window — needs tmux ≥3.1
 - `command`/`commands` and `start-directory` work per-pane (start-directory relative to the window's)
+- `title = "x"` titles a pane (`select-pane -T`); when any pane in a window has one, twin sets window-local `pane-border-status top` so titles are visible. Programs emitting terminal-title escapes can overwrite a title later — twin sets it once at creation
 - `focus = true` focuses that pane on open (default is pane 1); only one pane per window may set it
 - A window uses **either** window-level `command`/`commands` (single pane, the simple form above) **or** `panes`, never both
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Each recipe is a TOML file in the recipe directory. The filename becomes the ses
 start-directory = "~/Developer/pro/my-frontend/"
 
 [[windows]]
+name = "editor"
 start-directory = "src/"
 command = "nvim"
 
@@ -98,6 +99,8 @@ commands = ["npm install", "make run"]
 
 - `start-directory` (top-level) is required
 - `start-directory` on a window is relative to the recipe's top-level directory
+- `name = "x"` gives the window a fixed name; without it tmux shows the running
+  command (naming a window disables tmux's automatic-rename for it)
 - `command = "x"` runs a single command; omit it for a plain shell
 - `commands = ["x", "y"]` runs each entry as its own shell line — handy for a short
   setup sequence (or just chain with `&&`). Use `command` **or** `commands`, not both
@@ -110,6 +113,7 @@ A window can be split into multiple panes instead of holding a single shell:
 ```toml
 [[windows]]
   [[windows.panes]]
+  title = "vim"                # optional, shown in the pane border
   command = "nvim"             # pane 1 — the window's base pane
 
   [[windows.panes]]
@@ -130,6 +134,10 @@ A window can be split into multiple panes instead of holding a single shell:
 - `split-from = <N>` (1-based) chooses which pane to split; omit it to split the previous pane
 - `size` is a percentage like `"30%"`, optional — it's relative to the pane being split (needs tmux ≥3.1)
 - `command`/`commands`, `start-directory`, and `focus = true` (one per window) work per-pane
+- `title = "x"` titles a pane; when any pane in a window has one, twin turns on
+  `pane-border-status top` for that window so the titles are actually visible.
+  Programs that set the terminal title (via escape sequences) can overwrite a
+  pane title later — twin sets it once at creation
 - a window uses **either** `command`/`commands` or `panes`, never both
 
 ## Subcommands

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,7 @@ func (c Config) BorderColor(cmd string) Color {
 
 // Pane represents a single pane within a window.
 type Pane struct {
+	Title          string   `toml:"title"` // optional pane title (select-pane -T)
 	StartDirectory string   `toml:"start-directory"`
 	Command        string   `toml:"command"`    // single command; mutually exclusive with commands
 	Commands       []string `toml:"commands"`   // command list; mutually exclusive with command
@@ -78,6 +79,7 @@ type Pane struct {
 
 // Window represents a single window in a recipe.
 type Window struct {
+	Name           string   `toml:"name"` // optional window name (new-window -n)
 	StartDirectory string   `toml:"start-directory"`
 	Command        string   `toml:"command"`  // single command; mutually exclusive with commands
 	Commands       []string `toml:"commands"` // command list; mutually exclusive with command
@@ -196,12 +198,14 @@ func TemplatePath(recipeDir string) string {
 const templateContent = `start-directory = "~/"
 
 [[windows]]
+# name = "editor"                           # optional fixed window name
 # command = "nvim"                          # a single command
 # commands = ["npm install", "make run"]    # or a list, one shell line each
 
 # split a window into panes instead of using window-level command(s):
 # [[windows]]
 #   [[windows.panes]]
+#   title = "vim"     # optional pane title, shown in the pane border
 #   command = "nvim"
 #   [[windows.panes]]
 #   split = "right"   # or "down"; defaults to right

--- a/internal/icl/icl.go
+++ b/internal/icl/icl.go
@@ -239,8 +239,8 @@ const (
 	ansiOrange  = "\033[38;5;214m"
 	ansiReverse = "\033[7m"
 	ansiReset   = "\033[0m"
-	ansiClear = "\033[2J\033[H" // clear screen + cursor home
-	ansiDim   = "\033[2m"
+	ansiClear   = "\033[2J\033[H" // clear screen + cursor home
+	ansiDim     = "\033[2m"
 )
 
 // render draws the full TUI: tab bar, separator, preview, status line.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -28,8 +28,13 @@ func HasSession(name string) bool {
 // dragging every non-50% split toward 50%. Creating at the final size keeps
 // the percentages honest. Falls back to tmux's default when the size is
 // unknown (e.g. stdout isn't a terminal).
-func NewSession(name, startDir string) (string, error) {
+// windowName, when non-empty, names the first window; tmux then disables
+// automatic-rename for it, so the name sticks.
+func NewSession(name, startDir, windowName string) (string, error) {
 	args := []string{"new-session", "-d", "-s", name, "-c", startDir}
+	if windowName != "" {
+		args = append(args, "-n", windowName)
+	}
 	if cols, rows := SessionSize(); cols > 0 && rows > 0 {
 		args = append(args, "-x", strconv.Itoa(cols), "-y", strconv.Itoa(rows))
 	}
@@ -38,10 +43,15 @@ func NewSession(name, startDir string) (string, error) {
 }
 
 // NewWindow creates a new window in an existing session and returns the pane-id
-// of its base pane. target is "session:index" (e.g. "front:2").
-func NewWindow(target, startDir string) (string, error) {
-	return paneIDOf(exec.Command("tmux", "new-window", "-t", target,
-		"-c", startDir, "-P", "-F", "#{pane_id}"))
+// of its base pane. target is "session:index" (e.g. "front:2"). windowName,
+// when non-empty, names the window (disabling automatic-rename for it).
+func NewWindow(target, startDir, windowName string) (string, error) {
+	args := []string{"new-window", "-t", target, "-c", startDir}
+	if windowName != "" {
+		args = append(args, "-n", windowName)
+	}
+	args = append(args, "-P", "-F", "#{pane_id}")
+	return paneIDOf(exec.Command("tmux", args...))
 }
 
 // SplitPane splits the pane identified by targetPaneID and returns the new
@@ -65,6 +75,19 @@ func SplitPane(targetPaneID, startDir, direction, size string) (string, error) {
 // SelectPane focuses the pane identified by paneID (e.g. "%3").
 func SelectPane(paneID string) error {
 	return exec.Command("tmux", "select-pane", "-t", paneID).Run()
+}
+
+// SetPaneTitle sets the title of the pane identified by paneID. The title only
+// renders when the window's pane-border-status option is "top" or "bottom".
+func SetPaneTitle(paneID, title string) error {
+	return exec.Command("tmux", "select-pane", "-t", paneID, "-T", title).Run()
+}
+
+// EnablePaneBorderStatus turns on pane borders with titles for the window
+// containing paneID (-w resolves a pane target to its window).
+func EnablePaneBorderStatus(paneID string) error {
+	return exec.Command("tmux", "set-option", "-w", "-t", paneID,
+		"pane-border-status", "top").Run()
 }
 
 // paneIDOf runs a tmux command that prints a pane-id and returns it trimmed.

--- a/internal/tspmo/tspmo.go
+++ b/internal/tspmo/tspmo.go
@@ -145,12 +145,12 @@ func CreateSession(name string, recipe config.Recipe) error {
 		var basePaneID string
 		var err error
 		if i == 0 {
-			if basePaneID, err = tmux.NewSession(name, basePaneDir); err != nil {
+			if basePaneID, err = tmux.NewSession(name, basePaneDir, w.Name); err != nil {
 				return fmt.Errorf("new-session: %w", err)
 			}
 		} else {
 			target := fmt.Sprintf("%s:%d", name, i+1)
-			if basePaneID, err = tmux.NewWindow(target, basePaneDir); err != nil {
+			if basePaneID, err = tmux.NewWindow(target, basePaneDir, w.Name); err != nil {
 				return fmt.Errorf("new-window %s: %w", target, err)
 			}
 		}
@@ -176,6 +176,7 @@ func buildWindow(basePaneID string, w config.Window, windowDir string) error {
 
 	paneIDs := make([]string, len(w.Panes))
 	paneIDs[0] = basePaneID
+	setPaneTitle(basePaneID, w.Panes[0].Title)
 	if err := sendCommands(basePaneID, w.Panes[0].Cmds()); err != nil {
 		return err
 	}
@@ -199,9 +200,19 @@ func buildWindow(basePaneID string, w config.Window, windowDir string) error {
 			return fmt.Errorf("split pane %d: %w", i+1, err)
 		}
 		paneIDs[i] = id
+		setPaneTitle(id, p.Title)
 
 		if err := sendCommands(id, p.Cmds()); err != nil {
 			return err
+		}
+	}
+
+	// Titles are invisible in stock tmux; turn on the pane border for this
+	// window when any pane declares one, leaving other windows untouched.
+	for _, p := range w.Panes {
+		if p.Title != "" {
+			tmux.EnablePaneBorderStatus(basePaneID)
+			break
 		}
 	}
 
@@ -215,6 +226,13 @@ func buildWindow(basePaneID string, w config.Window, windowDir string) error {
 	tmux.SelectPane(focus)
 
 	return nil
+}
+
+// setPaneTitle applies a recipe pane title, ignoring empty ones.
+func setPaneTitle(paneID, title string) {
+	if title != "" {
+		tmux.SetPaneTitle(paneID, title)
+	}
 }
 
 // sendCommands dispatches each command to a tmux target (pane-id or window).


### PR DESCRIPTION
Closes #61.

`name = "x"` on a window → `new-window -n` (tmux disables auto-rename for explicitly named windows). `title = "x"` on a pane → `select-pane -T`; twin sets window-local `pane-border-status top` on windows with at least one titled pane so titles actually render.

Also includes a one-off gofmt fix for a pre-existing const-block misalignment in `internal/icl/icl.go`.

Verified against a throwaway session: name sticks, titles set, border status only on the titled window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDz18XeBuR1nuPYyxbFUD3